### PR TITLE
docs: update README, CASCADE.md and samples with correct cascade order

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@
 
 This agent skill implements a v4 cascade resolver that prioritizes free and low-cost data sources:
 
+### Query Resolution Cascade
 1. **Exa MCP** - FREE search via Model Context Protocol (no API key required!)
-2. **llms.txt** - Check for structured LLM documentation first (free)
-3. **Exa highlights** - Token-efficient query resolution using highlights (low-cost)
-4. **Tavily** - Fallback for comprehensive search (configurable)
-5. **DuckDuckGo** - Free search, always available (no API key)
-6. **Firecrawl** - Last resort for deep extraction (**requires API key**)
-7. **Mistral** - AI-powered fallback when other methods fail
+2. **Exa highlights** - Token-efficient query resolution using highlights (low-cost)
+3. **Tavily** - Fallback for comprehensive search (configurable)
+4. **DuckDuckGo** - Free search, always available (no API key)
+5. **Mistral** - AI-powered fallback when other methods fail
+
+### URL Resolution Cascade
+1. **llms.txt** - Check for structured LLM documentation first (free)
+2. **Firecrawl** - Deep extraction (**requires API key**)
+3. **Direct HTTP fetch** - Basic content extraction (free)
+4. **Mistral browser** - AI-powered fallback when other methods fail
 
 ## Features
 
@@ -144,8 +149,6 @@ python scripts/resolve.py "query" \
 
 ## How It Works
 
-The v4 cascade follows this decision tree:
-
 ### Query Resolution Cascade
 
 ```
@@ -156,7 +159,7 @@ Query Input
 │ 1. Exa MCP Search (FREE - no API key required!)            │
 │    - Uses Model Context Protocol at https://mcp.exa.ai/mcp  │
 │    - JSON-RPC 2.0 over HTTP POST                            │
-│    - Rate limit handling: 30s cooldown                      │
+│    - Rate limit handling: 30s cooldown                       │
 │    - On error: continue to next provider                    │
 └─────────────────────────────────────────────────────────────┘
     │ (fail)
@@ -218,7 +221,7 @@ URL Input
 │ 2. Firecrawl Extraction (if FIRECRAWL_API_KEY set)        │
 │    - Deep content extraction with markdown output           │
 │    - Rate limit handling: 60s cooldown                      │
-│    - On rate limit/quota: fallback to Mistral               │
+│    - On rate limit/quota: fallback to next provider         │
 │    - On auth error: return None                             │
 └─────────────────────────────────────────────────────────────┘
     │ (fail/unavailable)
@@ -239,7 +242,14 @@ URL Input
     │ (fail/unavailable)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 5. Return Error                                             │
+│ 5. DuckDuckGo Search (fallback)                            │
+│    - Search for the URL as a query                          │
+│    - FREE - no API key required                             │
+└─────────────────────────────────────────────────────────────┘
+    │ (fail)
+    ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 6. Return Error                                             │
 │    - source: "none"                                         │
 │    - error: "No resolution method available"               │
 └─────────────────────────────────────────────────────────────┘
@@ -277,8 +287,6 @@ Check the `samples/` directory for example usage:
 
 - `sample_basic.py` - Basic usage without API keys
 - `sample_with_keys.py` - Full cascade with all API keys
-- `sample_firecrawl.py` - Firecrawl-specific examples
-- `sample_error_handling.py` - Rate limit and error handling demos
 
 ## Pricing Information
 
@@ -325,144 +333,4 @@ For issues, questions, or feature requests, please [open an issue](https://githu
 
 ---
 
-**Note**: This skill prioritizes cost-efficiency and graceful degradation. It works perfectly fine with zero API keys configured, using only free sources (Exa MCP, llms.txt, DuckDuckGo, Mistral free tier). API keys enhance functionality but are not required.    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 3. DuckDuckGo Search (FREE - no API key required!)         │
-│    - Completely free, no authentication needed               │
-│    - Rate limit handling: 30s cooldown                      │
-│    - Always available as fallback                           │
-└─────────────────────────────────────────────────────────────┘
-    │ (fail)
-    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 4. Mistral Web Search (if MISTRAL_API_KEY set)              │
-│    - Uses Mistral agent with web browsing capability        │
-│    - Free tier available                                    │
-│    - Rate limit handling: 60s cooldown                      │
-└─────────────────────────────────────────────────────────────┘
-    │ (fail/unavailable)
-    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 5. Return Error                                             │
-│    - source: "none"                                         │
-│    - error: "No resolution method available"                │
-└─────────────────────────────────────────────────────────────┘
-```
-
-### URL Resolution Cascade
-
-```
-URL Input
-    │
-    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 1. Check for llms.txt                                       │
-│    - Probe: https://origin/llms.txt                        │
-│    - If found: return structured documentation              │
-│    - FREE - no API key required                             │
-└─────────────────────────────────────────────────────────────┘
-    │ (not found)
-    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 2. Firecrawl Extraction (if FIRECRAWL_API_KEY set)        │
-│    - Deep content extraction with markdown output           │
-│    - Rate limit handling: 60s cooldown                      │
-│    - On rate limit/quota: fallback to Mistral               │
-│    - On auth error: return None                             │
-└─────────────────────────────────────────────────────────────┘
-    │ (fail/unavailable)
-    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 3. Mistral Web Search (if MISTRAL_API_KEY set)            │
-│    - Uses Mistral agent with web browsing capability        │
-│    - Free tier available                                     │
-│    - Rate limit handling: 60s cooldown                      │
-└─────────────────────────────────────────────────────────────┘
-    │ (fail/unavailable)
-    ▼
-┌─────────────────────────────────────────────────────────────┐
-│ 4. Return Error                                             │
-│    - source: "none"                                         │
-│    - error: "No resolution method available"               │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## Error Handling & Self-Learning
-
-The resolver automatically handles:
-
-- **Rate Limits**: Detects 429 errors and falls back to next source
-- **No Credits**: Catches "no credits" errors and uses free alternatives
-- **Network Errors**: Graceful degradation through the cascade
-- **Invalid Responses**: Validates content before returning
-- **Missing API Keys**: Skips paid services when keys not configured
-
-## Testing
-
-```bash
-# Run all tests
-python -m pytest tests/
-
-# Run specific test
-python -m pytest tests/test_resolve.py::test_llms_txt_found
-
-# Run with coverage
-python -m pytest --cov=scripts tests/
-
-# Test cascade fallbacks
-python -m pytest tests/test_resolve.py::test_cascade_with_rate_limits
-```
-
-## Sample Files
-
-Check the `samples/` directory for example usage:
-
-- `sample_basic.py` - Basic usage without API keys
-- `sample_with_keys.py` - Full cascade with all API keys
-- `sample_firecrawl.py` - Firecrawl-specific examples
-- `sample_error_handling.py` - Rate limit and error handling demos
-
-## Pricing Information
-
-### Free Tier Options
-
-- **llms.txt**: 100% free, static file check
-- **Mistral agent-browser**: Free tier available
-- **Basic web scraping**: No API key needed
-
-### Paid Options
-
-- **Exa**: Token-efficient, pay-per-search ([exa.ai/pricing](https://exa.ai/pricing))
-- **Tavily**: Comprehensive search, tiered pricing ([tavily.com/pricing](https://tavily.com/))
-- **Firecrawl**: Deep extraction, credit-based ([firecrawl.dev/pricing](https://www.firecrawl.dev/pricing))
-  - **Requires API key** - No free tier for API access
-  - Skipped entirely if `FIRECRAWL_API_KEY` not set
-
-## Related Files
-
-- [`SKILL.md`](SKILL.md) - Full agent skill specification
-- [`AGENTS.md`](AGENTS.md) - Agent usage documentation
-- [`scripts/resolve.py`](scripts/resolve.py) - Implementation source code
-- [`.github/workflows/ci.yml`](.github/workflows/ci.yml) - CI/CD pipeline
-
-## Contributing
-
-Contributions are welcome! Please:
-
-1. Fork the repository
-2. Create a feature branch
-3. Add tests for new functionality
-4. Ensure CI passes
-5. Submit a pull request
-
-## License
-
-MIT License - see LICENSE file for details
-
-## Support
-
-For issues, questions, or feature requests, please [open an issue](https://github.com/d-oit/web-doc-resolver/issues).
-
----
-
-**Note**: This skill prioritizes cost-efficiency and graceful degradation. It works perfectly fine with zero API keys configured, using only free sources (llms.txt, basic scraping, Mistral). API keys enhance functionality but are not required except for Firecrawl, which is completely optional and only activates when its API key is provided.
+**Note**: This skill prioritizes cost-efficiency and graceful degradation. It works perfectly fine with zero API keys configured, using only free sources (Exa MCP, llms.txt, DuckDuckGo, Mistral free tier). API keys enhance functionality but are not required.

--- a/references/CASCADE.md
+++ b/references/CASCADE.md
@@ -56,7 +56,7 @@ Query Input
     ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ 6. Mistral Web Search (if MISTRAL_API_KEY set)              │
-│    - Uses Mistral agent with web browsing capability        │
+│    - Uses Mistral chat API with web search                  │
 │    - Free tier available                                    │
 │    - Rate limit handling: 60s cooldown                      │
 └─────────────────────────────────────────────────────────────┘
@@ -96,13 +96,20 @@ URL Input
 │ 3. Firecrawl Extraction (if FIRECRAWL_API_KEY set)        │
 │    - Deep content extraction with markdown output           │
 │    - Rate limit handling: 60s cooldown                      │
-│    - On rate limit/quota: fallback to Mistral               │
+│    - On rate limit/quota: fallback to next provider         │
 │    - On auth error: return None                             │
 └─────────────────────────────────────────────────────────────┘
     │ (fail/unavailable)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 4. Mistral Web Search (if MISTRAL_API_KEY set)            │
+│ 4. Direct HTTP Fetch                                        │
+│    - Basic content extraction from HTML                     │
+│    - FREE - no API key required                             │
+└─────────────────────────────────────────────────────────────┘
+    │ (fail)
+    ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 5. Mistral Browser (if MISTRAL_API_KEY set)               │
 │    - Uses Mistral agent with web browsing capability        │
 │    - Free tier available                                     │
 │    - Rate limit handling: 60s cooldown                      │
@@ -110,7 +117,14 @@ URL Input
     │ (fail/unavailable)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 5. Return Error                                             │
+│ 6. DuckDuckGo Search (fallback)                            │
+│    - Search for the URL as a query                          │
+│    - FREE - no API key required                             │
+└─────────────────────────────────────────────────────────────┘
+    │ (fail)
+    ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 7. Return Error                                             │
 │    - source: "none"                                         │
 │    - error: "No resolution method available"               │
 └─────────────────────────────────────────────────────────────┘
@@ -133,7 +147,7 @@ URL Input
 The resolver maintains an in-memory rate limit tracker:
 
 ```python
-_rate_limits: Dict[str, float] = {}
+_rate_limits: dict[str, float] = {}
 
 def _is_rate_limited(provider: str, cooldown: int = 60) -> bool:
     # Returns True if provider is in cooldown period
@@ -185,7 +199,7 @@ def _cache_key(input_str: str, source: str) -> str:
 
 ### For Query Resolution
 
-1. **Exa MCP is now the primary**: Free, no API key required, high-quality results
+1. **Exa MCP is the primary**: Free, no API key required, high-quality results
 2. **DuckDuckGo as backup baseline**: Always works without API keys
 3. **Add Exa SDK for enhanced results**: Token-efficient highlights with API key
 4. **Add Tavily for comprehensive search**: More detailed results
@@ -195,7 +209,8 @@ def _cache_key(input_str: str, source: str) -> str:
 
 1. **llms.txt is always checked first**: Free and structured
 2. **Firecrawl for complex sites**: Best extraction quality
-3. **Mistral as fallback**: Works when Firecrawl fails
+3. **Direct HTTP fetch as fallback**: Works for most sites
+4. **Mistral as final fallback**: Works when other methods fail
 
 ### Cost Optimization
 
@@ -210,9 +225,10 @@ def _cache_key(input_str: str, source: str) -> str:
 
 ```json
 {
-  "source": "duckduckgo",
+  "source": "exa_mcp",
   "query": "Rust agent frameworks",
-  "content": "# Search Results for: Rust agent frameworks\n\n## Tokio\n\nTokio is a popular asynchronous runtime...\n\nSource: https://tokio.rs\n\n---\n\n## Actix\n\nActix is a powerful web framework..."
+  "content": "# Search Results for: Rust agent frameworks\n\n## Tokio\n\nTokio is a popular asynchronous runtime...\n\nSource: https://tokio.rs\n\n---\n\n## Actix\n\nActix is a powerful web framework...",
+  "validated_links": ["https://tokio.rs", "https://actix.rs"]
 }
 ```
 
@@ -222,7 +238,8 @@ def _cache_key(input_str: str, source: str) -> str:
 {
   "source": "llms.txt",
   "url": "https://example.com/docs",
-  "content": "# Documentation\n\n## Getting Started\n..."
+  "content": "# Documentation\n\n## Getting Started\n...",
+  "validated_links": []
 }
 ```
 

--- a/samples/sample_basic.py
+++ b/samples/sample_basic.py
@@ -3,8 +3,9 @@
 Basic usage example without API keys.
 
 This demonstrates using web-doc-resolver with free sources only:
-- llms.txt checks
-- Free fallbacks
+- llms.txt checks for URLs
+- Exa MCP for queries (free, no API key required)
+- DuckDuckGo as fallback
 - No API keys required
 """
 
@@ -16,25 +17,32 @@ def main():
     print("web-doc-resolver: Basic Usage (No API Keys)")
     print("=" * 60)
     print()
+    print("Free providers used:")
+    print("  - Exa MCP (free search, no API key)")
+    print("  - llms.txt (free URL documentation)")
+    print("  - DuckDuckGo (free fallback)")
+    print()
 
-    # Example 1: Resolve a URL
+    # Example 1: Resolve a URL (checks llms.txt first)
     print("Example 1: Resolving a URL...")
     print("-" * 60)
     url = "https://example.com"
     result = resolve(url)
     print(f"Input: {url}")
-    print(f"Result length: {len(result)} characters")
-    print(f"Preview: {result[:200]}...")
+    print(f"Source: {result.get('source', 'unknown')}")
+    print(f"Result length: {len(result.get('content', ''))} characters")
+    print(f"Preview: {result.get('content', '')[:200]}...")
     print()
 
-    # Example 2: Resolve a query
+    # Example 2: Resolve a query (uses Exa MCP - free!)
     print("Example 2: Resolving a query...")
     print("-" * 60)
     query = "latest AI research papers"
     result = resolve(query)
     print(f"Input: {query}")
-    print(f"Result length: {len(result)} characters")
-    print(f"Preview: {result[:200]}...")
+    print(f"Source: {result.get('source', 'unknown')}")
+    print(f"Result length: {len(result.get('content', ''))} characters")
+    print(f"Preview: {result.get('content', '')[:200]}...")
     print()
 
     # Example 3: Another URL example
@@ -43,13 +51,27 @@ def main():
     url2 = "https://github.com"
     result = resolve(url2)
     print(f"Input: {url2}")
-    print(f"Result length: {len(result)} characters")
-    print(f"Preview: {result[:200]}...")
+    print(f"Source: {result.get('source', 'unknown')}")
+    print(f"Result length: {len(result.get('content', ''))} characters")
+    print(f"Preview: {result.get('content', '')[:200]}...")
+    print()
+
+    # Example 4: Skip providers to test fallbacks
+    print("Example 4: Skip Exa MCP to test fallbacks...")
+    print("-" * 60)
+    query = "Python async programming"
+    result = resolve(query, skip_providers={"exa_mcp"})
+    print(f"Input: {query}")
+    print("Skipped: exa_mcp")
+    print(f"Source: {result.get('source', 'unknown')}")
+    print(f"Result length: {len(result.get('content', ''))} characters")
     print()
 
     print("=" * 60)
     print("All examples completed successfully!")
-    print("Note: These results use only free sources (llms.txt, fallbacks)")
+    print("Note: These results use only free sources")
+    print("  - Exa MCP (free, no API key)")
+    print("  - DuckDuckGo (free fallback)")
     print("=" * 60)
 
 

--- a/samples/sample_with_keys.py
+++ b/samples/sample_with_keys.py
@@ -3,10 +3,12 @@
 Example usage with all API keys configured.
 
 This demonstrates the full cascade with enhanced features:
-- Exa highlights for efficient search
-- Tavily for comprehensive results
-- Firecrawl for deep extraction (requires API key)
-- Mistral as fallback
+- Exa MCP (free, no API key required) - primary search
+- Exa SDK (if EXA_API_KEY set) - enhanced search
+- Tavily (if TAVILY_API_KEY set) - comprehensive results
+- DuckDuckGo (free fallback)
+- Firecrawl (if FIRECRAWL_API_KEY set) - deep URL extraction
+- Mistral (if MISTRAL_API_KEY set) - AI-powered fallback
 """
 
 import os
@@ -35,50 +37,76 @@ def main():
         print(f"{key_name}: {status}")
     print()
 
-    # Example 1: Complex URL with Firecrawl
-    print("Example 1: Deep extraction with Firecrawl...")
+    print("Cascade Order (Query):")
+    print("  1. Exa MCP (free, no API key)")
+    print("  2. Exa SDK (if EXA_API_KEY set)")
+    print("  3. Tavily (if TAVILY_API_KEY set)")
+    print("  4. DuckDuckGo (free fallback)")
+    print("  5. Mistral (if MISTRAL_API_KEY set)")
+    print()
+
+    print("Cascade Order (URL):")
+    print("  1. llms.txt check (free)")
+    print("  2. Firecrawl (if FIRECRAWL_API_KEY set)")
+    print("  3. Direct HTTP fetch (free)")
+    print("  4. Mistral browser (if MISTRAL_API_KEY set)")
+    print("  5. DuckDuckGo search (free fallback)")
+    print()
+
+    # Example 1: Query with full cascade
+    print("Example 1: Query resolution with full cascade...")
+    print("-" * 60)
+    query = "latest machine learning research 2024"
+    result = resolve(query)
+    print(f"Input: {query}")
+    print(f"Source: {result.get('source', 'unknown')}")
+    print(f"Result length: {len(result.get('content', ''))} characters")
+    print(f"Preview: {result.get('content', '')[:300]}...")
+    print()
+
+    # Example 2: URL with llms.txt check first
+    print("Example 2: URL resolution (llms.txt first)...")
     print("-" * 60)
     if keys["FIRECRAWL_API_KEY"]:
         url = "https://docs.python.org/3/library/asyncio.html"
         result = resolve(url)
         print(f"Input: {url}")
-        print(f"Result length: {len(result)} characters")
-        print(f"Preview: {result[:300]}...")
+        print(f"Source: {result.get('source', 'unknown')}")
+        print(f"Result length: {len(result.get('content', ''))} characters")
+        print(f"Preview: {result.get('content', '')[:300]}...")
     else:
         print("Skipped: FIRECRAWL_API_KEY not set")
         print("Set FIRECRAWL_API_KEY to enable deep extraction")
+        print("Note: llms.txt and direct fetch still work without API keys")
     print()
 
-    # Example 2: Query with Exa highlights
-    print("Example 2: Token-efficient search with Exa...")
-    print("-" * 60)
-    if keys["EXA_API_KEY"]:
-        query = "latest machine learning research 2024"
-        result = resolve(query)
-        print(f"Input: {query}")
-        print(f"Result length: {len(result)} characters")
-        print(f"Preview: {result[:300]}...")
-    else:
-        print("Skipped: EXA_API_KEY not set (will use free fallback)")
-        query = "latest machine learning research 2024"
-        result = resolve(query)
-        print(f"Using free fallback for: {query}")
-        print(f"Result length: {len(result)} characters")
-    print()
-
-    # Example 3: Tavily comprehensive search
-    print("Example 3: Comprehensive search with Tavily...")
+    # Example 3: Skip providers to test specific fallbacks
+    print("Example 3: Test specific providers by skipping others...")
     print("-" * 60)
     query = "rust async programming best practices"
-    result = resolve(query)
+    print("Testing: Skip Exa MCP and Exa SDK to use Tavily/DuckDuckGo")
+    result = resolve(query, skip_providers={"exa_mcp", "exa"})
     print(f"Input: {query}")
-    print(f"Result length: {len(result)} characters")
-    print(f"Preview: {result[:300]}...")
+    print("Skipped: exa_mcp, exa")
+    print(f"Source: {result.get('source', 'unknown')}")
+    print(f"Result length: {len(result.get('content', ''))} characters")
+    print()
+
+    # Example 4: Use only free providers
+    print("Example 4: Use only free providers...")
+    print("-" * 60)
+    query = "web scraping best practices"
+    result = resolve(query, skip_providers={"exa", "tavily", "mistral"})
+    print(f"Input: {query}")
+    print("Skipped: exa, tavily, mistral (using only free providers)")
+    print(f"Source: {result.get('source', 'unknown')}")
+    print(f"Result length: {len(result.get('content', ''))} characters")
     print()
 
     print("=" * 60)
     print("All examples completed!")
     print("Note: Results vary based on which API keys are configured")
+    print("      Free providers (Exa MCP, DuckDuckGo) always work")
     print("=" * 60)
 
 


### PR DESCRIPTION
## Summary

- Fix README.md with proper cascade documentation (removed duplicate content)
- Update CASCADE.md with correct URL resolution order (llms.txt first)
- Update sample_basic.py with better examples and skip_providers demo
- Update sample_with_keys.py with cascade order documentation
- Fix linting issues in sample files

## Changes

### README.md
- Fixed corrupted/duplicate content at the end
- Clarified cascade order for both query and URL resolution
- Updated documentation to reflect current implementation

### CASCADE.md
- Added DuckDuckGo fallback to URL resolution cascade
- Updated cascade diagrams with correct order

### samples/
- sample_basic.py: Added skip_providers example
- sample_with_keys.py: Added cascade order documentation

## Testing
- All 93 tests pass
- Linting passes (ruff, black, mypy)