### PR TITLE
feat: Jina Reader free provider + llms.txt cache + persistent rate limits + direct provider selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
-<!-- skill: web-doc-resolver v1.2.0 -->
-<!-- source: https://github.com/d-oit/web-doc-resolver/tree/v1.2.0 -->
+<!-- skill: web-doc-resolver v1.3.0 -->
+<!-- source: https://github.com/d-oit/web-doc-resolver/tree/v1.3.0 -->
 
 # Agent Instructions
 
@@ -53,16 +53,20 @@ web-doc-resolver/
 
 The resolver uses a **cascade strategy** to minimize API calls and token usage:
 
-1. **For URLs**: Probes `llms.txt` first → falls back to Firecrawl → Direct fetch → Mistral fallback
-2. **For queries**: Uses **Exa MCP (FREE)** first → Exa SDK → Tavily → DuckDuckGo (free) → Mistral fallback
+### URL Resolution Cascade
+1. **llms.txt** (cached per origin, 1-hour TTL) - FREE
+2. **Jina Reader** (r.jina.ai) - FREE, no API key
+3. **Firecrawl** - deep extraction (requires API key)
+4. **Direct HTTP fetch** - FREE
+5. **Mistral browser** - AI-powered fallback
+6. **DuckDuckGo search** - FREE fallback
 
-This approach:
-- **Exa MCP is now primary**: Free search via Model Context Protocol (no API key!)
-- Prioritizes site-provided structured docs (llms.txt)
-- Uses Exa highlights for token-efficient search
-- Calls Tavily only when Exa returns insufficient results
-- Falls back to DuckDuckGo (completely free, no API key needed)
-- Uses Mistral as final AI-powered fallback
+### Query Resolution Cascade
+1. **Exa MCP** - FREE via Model Context Protocol (no API key!)
+2. **Exa SDK** - token-efficient highlights (optional API key)
+3. **Tavily** - comprehensive search (optional API key)
+4. **DuckDuckGo** - FREE, always available
+5. **Mistral websearch** - AI-powered fallback
 
 ## Running the Script
 
@@ -84,6 +88,40 @@ python scripts/resolve.py "https://docs.rs/tokio/latest/tokio/"
 python scripts/resolve.py "query" --max-chars 8000 --log-level INFO --json
 ```
 
+### Use a Specific Provider Directly
+
+Bypass the cascade and use a single provider:
+
+```bash
+# Use Jina Reader directly for a URL
+python scripts/resolve.py "https://example.com" --provider jina
+
+# Use Exa MCP directly for a query
+python scripts/resolve.py "python tutorials" --provider exa_mcp
+
+# Use DuckDuckGo directly
+python scripts/resolve.py "latest news" --provider duckduckgo
+```
+
+Available providers:
+- **URL providers**: `llms_txt`, `jina`, `firecrawl`, `direct_fetch`, `mistral_browser`, `duckduckgo`
+- **Query providers**: `exa_mcp`, `exa`, `tavily`, `duckduckgo`, `mistral_websearch`
+
+### Custom Provider Order
+
+Override the default cascade with your own order:
+
+```bash
+# Use only free providers for URLs (no API keys needed)
+python scripts/resolve.py "https://example.com" --providers-order "llms_txt,jina,direct_fetch"
+
+# Use only free providers for queries
+python scripts/resolve.py "python tutorials" --providers-order "exa_mcp,duckduckgo"
+
+# Prefer Jina over Firecrawl
+python scripts/resolve.py "https://docs.example.com" --providers-order "llms_txt,jina,direct_fetch,duckduckgo"
+```
+
 ### Skip Specific Providers
 
 ```bash
@@ -97,6 +135,38 @@ python scripts/resolve.py "query" --skip exa_mcp --skip exa --skip tavily --skip
 python scripts/resolve.py "query" --skip exa_mcp --skip exa --skip tavily --skip mistral
 ```
 
+### Python API
+
+```python
+from scripts.resolve import (
+    resolve,
+    resolve_direct,
+    resolve_with_order,
+    ProviderType,
+    DEFAULT_URL_PROVIDERS,
+    DEFAULT_QUERY_PROVIDERS,
+)
+
+# Default cascade
+result = resolve("https://example.com")
+
+# Use a specific provider directly
+result = resolve_direct("https://example.com", ProviderType.JINA)
+result = resolve_direct("python tutorials", ProviderType.EXA_MCP)
+
+# Custom provider order
+result = resolve_with_order(
+    "https://example.com",
+    [ProviderType.LLMS_TXT, ProviderType.JINA, ProviderType.DIRECT_FETCH]
+)
+
+# Use only free providers for queries
+result = resolve_with_order(
+    "python tutorials",
+    [ProviderType.EXA_MCP, ProviderType.DUCKDUCKGO]
+)
+```
+
 ## Environment Variables (all optional)
 
 | Variable | Provider | Notes |
@@ -106,7 +176,7 @@ python scripts/resolve.py "query" --skip exa_mcp --skip exa --skip tavily --skip
 | `FIRECRAWL_API_KEY` | Firecrawl | Optional - deep extraction |
 | `MISTRAL_API_KEY` | Mistral | Optional - AI-powered fallback |
 
-**Note**: Exa MCP and DuckDuckGo are always available as free fallbacks (no API key required).
+**Note**: Exa MCP, Jina Reader, and DuckDuckGo are always available as free fallbacks (no API key required).
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,53 @@ result = resolve("query", skip_providers={"exa_mcp", "exa"})
 result = resolve("query", skip_providers={"exa_mcp", "exa", "tavily", "duckduckgo"})
 ```
 
+### Use a Specific Provider Directly
+
+Bypass the cascade and use a single provider:
+
+```python
+from scripts.resolve import resolve_direct, ProviderType
+
+# Use Jina Reader directly for a URL
+result = resolve_direct("https://example.com", ProviderType.JINA)
+
+# Use Exa MCP directly for a query
+result = resolve_direct("python tutorials", ProviderType.EXA_MCP)
+
+# Use DuckDuckGo directly
+result = resolve_direct("latest news", ProviderType.DUCKDUCKGO)
+```
+
+Available providers:
+- **URL providers**: `llms_txt`, `jina`, `firecrawl`, `direct_fetch`, `mistral_browser`, `duckduckgo`
+- **Query providers**: `exa_mcp`, `exa`, `tavily`, `duckduckgo`, `mistral_websearch`
+
+### Custom Provider Order
+
+Override the default cascade with your own order:
+
+```python
+from scripts.resolve import resolve_with_order, ProviderType
+
+# Use only free providers for URLs (no API keys needed)
+result = resolve_with_order(
+    "https://example.com",
+    [ProviderType.LLMS_TXT, ProviderType.JINA, ProviderType.DIRECT_FETCH]
+)
+
+# Use only free providers for queries
+result = resolve_with_order(
+    "python tutorials",
+    [ProviderType.EXA_MCP, ProviderType.DUCKDUCKGO]
+)
+
+# Prefer Jina over Firecrawl for URLs
+result = resolve_with_order(
+    "https://docs.example.com",
+    [ProviderType.LLMS_TXT, ProviderType.JINA, ProviderType.DIRECT_FETCH, ProviderType.DUCKDUCKGO]
+)
+```
+
 ### Command Line
 
 ```bash
@@ -145,6 +192,14 @@ python scripts/resolve.py "query" --skip exa_mcp --skip exa
 python scripts/resolve.py "query" \
   --skip exa_mcp --skip exa --skip tavily --skip duckduckgo \
   --log-level INFO --json
+
+# Use a specific provider directly
+python scripts/resolve.py "https://example.com" --provider jina
+python scripts/resolve.py "python tutorials" --provider exa_mcp
+
+# Use a custom provider order
+python scripts/resolve.py "https://example.com" --providers-order "llms_txt,jina,direct_fetch"
+python scripts/resolve.py "python tutorials" --providers-order "exa_mcp,duckduckgo"
 ```
 
 ## How It Works
@@ -156,16 +211,16 @@ Query Input
     │
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 1. Exa MCP Search (FREE - no API key required!)            │
+│ 1. Exa MCP Search (FREE - no API key required!)             │
 │    - Uses Model Context Protocol at https://mcp.exa.ai/mcp  │
 │    - JSON-RPC 2.0 over HTTP POST                            │
-│    - Rate limit handling: 30s cooldown                       │
+│    - Rate limit handling: 30s cooldown                      │
 │    - On error: continue to next provider                    │
 └─────────────────────────────────────────────────────────────┘
     │ (fail)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 2. Exa SDK Search (if EXA_API_KEY set)                     │
+│ 2. Exa SDK Search (if EXA_API_KEY set)                      │
 │    - Uses highlights for token-efficient results            │
 │    - Rate limit handling: 60s cooldown                      │
 │    - On error: continue to next provider                    │
@@ -173,7 +228,7 @@ Query Input
     │ (fail/unavailable)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 3. Tavily Search (if TAVILY_API_KEY set)                   │
+│ 3. Tavily Search (if TAVILY_API_KEY set)                    │
 │    - Comprehensive search results                           │
 │    - Rate limit handling: 60s cooldown                      │
 │    - On error: continue to next provider                    │
@@ -181,8 +236,8 @@ Query Input
     │ (fail/unavailable)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 4. DuckDuckGo Search (FREE - no API key required!)         │
-│    - Completely free, no authentication needed               │
+│ 4. DuckDuckGo Search (FREE - no API key required!)          │
+│    - Completely free, no authentication needed              │
 │    - Rate limit handling: 30s cooldown                      │
 │    - Always available as fallback                           │
 └─────────────────────────────────────────────────────────────┘
@@ -211,14 +266,23 @@ URL Input
     ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ 1. Check for llms.txt                                       │
-│    - Probe: https://origin/llms.txt                        │
+│    - Probe: https://origin/llms.txt                         │
 │    - If found: return structured documentation              │
 │    - FREE - no API key required                             │
+│    - Cached per origin (1-hour TTL)                         │
 └─────────────────────────────────────────────────────────────┘
     │ (not found)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 2. Firecrawl Extraction (if FIRECRAWL_API_KEY set)        │
+│ 2. Jina Reader (FREE - https://r.jina.ai/<url>)             │
+│    - No API key required, 20 RPM free tier                  │
+│    - Returns clean markdown for any public URL              │
+│    - Rate limit handling: 60s cooldown                      │
+└─────────────────────────────────────────────────────────────┘
+    │ (fail)
+    ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. Firecrawl Extraction (if FIRECRAWL_API_KEY set)          │
 │    - Deep content extraction with markdown output           │
 │    - Rate limit handling: 60s cooldown                      │
 │    - On rate limit/quota: fallback to next provider         │
@@ -227,31 +291,31 @@ URL Input
     │ (fail/unavailable)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 3. Direct HTTP Fetch                                        │
+│ 4. Direct HTTP Fetch                                        │
 │    - Basic content extraction from HTML                     │
 │    - FREE - no API key required                             │
 └─────────────────────────────────────────────────────────────┘
     │ (fail)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 4. Mistral Browser (if MISTRAL_API_KEY set)               │
+│ 5. Mistral Browser (if MISTRAL_API_KEY set)                 │
 │    - Uses Mistral agent with web browsing capability        │
-│    - Free tier available                                     │
+│    - Free tier available                                    │
 │    - Rate limit handling: 60s cooldown                      │
 └─────────────────────────────────────────────────────────────┘
     │ (fail/unavailable)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 5. DuckDuckGo Search (fallback)                            │
+│ 6. DuckDuckGo Search (fallback)                             │
 │    - Search for the URL as a query                          │
 │    - FREE - no API key required                             │
 └─────────────────────────────────────────────────────────────┘
     │ (fail)
     ▼
 ┌─────────────────────────────────────────────────────────────┐
-│ 6. Return Error                                             │
+│ 7. Return Error                                             │
 │    - source: "none"                                         │
-│    - error: "No resolution method available"               │
+│    - error: "No resolution method available"                │
 └─────────────────────────────────────────────────────────────┘
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ tavily-python>=0.3.0  # Tavily search API - free tier available
 firecrawl-py>=0.0.5  # Firecrawl extraction - free tier available
 mistralai>=1.0.0  # Mistral agent-browser skill fallback - free tier available
 ddgs>=2.0.0  # DuckDuckGo search - FREE, no API key required (replaces duckduckgo-search)
+httpx>=0.27.0  # optional faster async client (used by Jina if available)
 
 # Development dependencies
 pytest>=7.4.0

--- a/scripts/resolve.py
+++ b/scripts/resolve.py
@@ -10,8 +10,8 @@ A comprehensive web research tool with:
 - Real-time web search and content extraction
 - SSRF protection and content size limits
 
-Cascade order for queries: Exa → Tavily → DuckDuckGo → Mistral
-Cascade order for URLs: llms.txt → Firecrawl → Direct HTTP fetch → Mistral browser → DuckDuckGo
+Cascade order for queries: Exa MCP → Exa SDK → Tavily → DuckDuckGo → Mistral
+Cascade order for URLs: llms.txt (cached) → Jina Reader (free) → Firecrawl → Direct HTTP fetch → Mistral browser → DuckDuckGo
 """
 
 import argparse
@@ -74,6 +74,34 @@ BLOCKED_SCHEMES: set[str] = {"file", "javascript", "data", "vbscript"}
 # Rate limit tracking
 _rate_limits: dict[str, float] = {}
 
+RATE_LIMIT_FILE = os.path.join(CACHE_DIR, "rate_limits.json")
+
+
+def _load_rate_limits() -> dict[str, float]:
+    """Load persisted rate-limit state from disk."""
+    try:
+        if os.path.exists(RATE_LIMIT_FILE):
+            with open(RATE_LIMIT_FILE) as f:
+                data = json.load(f)
+                return {k: float(v) for k, v in data.items()}
+    except Exception:
+        pass
+    return {}
+
+
+def _save_rate_limits() -> None:
+    """Persist rate-limit state to disk so re-invoked processes respect cooldowns."""
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        with open(RATE_LIMIT_FILE, "w") as f:
+            json.dump(_rate_limits, f)
+    except Exception:
+        pass
+
+
+# Initialise from disk on import
+_rate_limits.update(_load_rate_limits())
+
 # Global session for connection pooling
 _global_session: requests.Session | None = None
 
@@ -82,14 +110,22 @@ __all__ = [
     "resolve",
     "resolve_url",
     "resolve_query",
+    "resolve_direct",
+    "resolve_with_order",
+    "resolve_url_with_order",
+    "resolve_query_with_order",
     "ResolvedResult",
     "ValidationResult",
     "ErrorType",
+    "ProviderType",
+    "DEFAULT_URL_PROVIDERS",
+    "DEFAULT_QUERY_PROVIDERS",
     "is_url",
     "validate_url",
     "validate_links",
     "fetch_url_content",
     "fetch_llms_txt",
+    "resolve_with_jina",
     "resolve_with_exa_mcp",
     "resolve_with_exa",
     "resolve_with_tavily",
@@ -117,6 +153,43 @@ class ErrorType(Enum):
     SSRF_BLOCKED = "ssrf_blocked"
     CONTENT_TOO_LARGE = "content_too_large"
     UNKNOWN = "unknown"
+
+
+class ProviderType(Enum):
+    """Available providers for resolution."""
+
+    # URL providers
+    LLMS_TXT = "llms_txt"
+    JINA = "jina"
+    FIRECRAWL = "firecrawl"
+    DIRECT_FETCH = "direct_fetch"
+    MISTRAL_BROWSER = "mistral_browser"
+
+    # Query providers
+    EXA_MCP = "exa_mcp"
+    EXA = "exa"
+    TAVILY = "tavily"
+    DUCKDUCKGO = "duckduckgo"
+    MISTRAL_WEBSEARCH = "mistral_websearch"
+
+
+# Default provider orders
+DEFAULT_URL_PROVIDERS: list[ProviderType] = [
+    ProviderType.LLMS_TXT,
+    ProviderType.JINA,
+    ProviderType.FIRECRAWL,
+    ProviderType.DIRECT_FETCH,
+    ProviderType.MISTRAL_BROWSER,
+    ProviderType.DUCKDUCKGO,
+]
+
+DEFAULT_QUERY_PROVIDERS: list[ProviderType] = [
+    ProviderType.EXA_MCP,
+    ProviderType.EXA,
+    ProviderType.TAVILY,
+    ProviderType.DUCKDUCKGO,
+    ProviderType.MISTRAL_WEBSEARCH,
+]
 
 
 @dataclass
@@ -292,6 +365,7 @@ def _set_rate_limit(provider: str, cooldown: int = 60) -> None:
     """Set a rate limit cooldown for a provider."""
     _rate_limits[provider] = time.time() + cooldown
     logger.warning(f"Rate limit set for {provider}, cooldown: {cooldown}s")
+    _save_rate_limits()
 
 
 def _detect_error_type(error: Exception) -> ErrorType:
@@ -393,14 +467,14 @@ def _get_from_cache(input_str: str, source: str) -> dict[str, Any] | None:
     return None
 
 
-def _save_to_cache(input_str: str, source: str, result: dict[str, Any]):
+def _save_to_cache(input_str: str, source: str, result: dict[str, Any], ttl: int | None = None):
     """Save result to cache."""
     cache = _get_cache()
     if not cache:
         return
     try:
         key = _cache_key(input_str, source)
-        cache.set(key, result, expire=CACHE_TTL)
+        cache.set(key, result, expire=ttl if ttl is not None else CACHE_TTL)
     except Exception as e:
         logger.debug(f"Cache write error: {e}")
 
@@ -653,25 +727,38 @@ def fetch_url_content(
 def fetch_llms_txt(url: str) -> str | None:
     """
     Check for llms.txt file at the site root.
-
-    llms.txt is a proposed standard for LLM-readable documentation.
+    Results are cached per origin domain with a 1-hour TTL to avoid
+    probing the same domain on every call.
     """
     try:
         parsed = urlparse(url)
         base_url = f"{parsed.scheme}://{parsed.netloc}"
         llms_url = f"{base_url}/llms.txt"
 
-        logger.info(f"Checking for llms.txt at {llms_url}")
+        # Check cache first (keyed by origin, not full URL)
+        cached = _get_from_cache(base_url, "llms_txt")
+        if cached is not None:
+            # cached can be {"found": False} or {"found": True, "content": "..."}
+            if cached.get("found"):
+                logger.debug(f"llms.txt cache hit for {base_url}")
+                return str(cached.get("content", ""))
+            else:
+                logger.debug(f"llms.txt known-missing for {base_url}, skipping probe")
+                return None
 
+        logger.info(f"Checking for llms.txt at {llms_url}")
         session = get_session()
         response = session.get(llms_url, timeout=10, allow_redirects=True)
-        # session is managed globally
 
         if response.status_code == 200:
             content_type = response.headers.get("Content-Type", "")
             if "text" in content_type or "markdown" in content_type:
                 logger.info(f"Found llms.txt at {llms_url}")
+                _save_to_cache(base_url, "llms_txt", {"found": True, "content": response.text}, ttl=3600)
                 return response.text
+
+        # Cache the miss so we don't probe again for 1 hour
+        _save_to_cache(base_url, "llms_txt", {"found": False}, ttl=3600)
     except Exception as e:
         logger.debug(f"No llms.txt found: {e}")
     return None
@@ -680,6 +767,60 @@ def fetch_llms_txt(url: str) -> str | None:
 # ============================================================================
 # Provider Implementations
 # ============================================================================
+
+
+def resolve_with_jina(url: str, max_chars: int = MAX_CHARS) -> ResolvedResult | None:
+    """
+    Extract content from a URL using Jina Reader (r.jina.ai).
+    Completely FREE - no API key required, 20 RPM without key.
+    Returns clean markdown output.
+    """
+    cached = _get_from_cache(url, "jina")
+    if cached:
+        return ResolvedResult(**cached)
+
+    if _is_rate_limited("jina"):
+        logger.warning("Jina Reader is rate-limited, skipping")
+        return None
+
+    try:
+        jina_url = f"https://r.jina.ai/{url}"
+        logger.info(f"Using Jina Reader to extract: {url}")
+        session = get_session()
+        response = session.get(
+            jina_url,
+            timeout=DEFAULT_TIMEOUT,
+            headers={"Accept": "text/markdown"},
+        )
+
+        if response.status_code == 429:
+            logger.warning("Jina Reader rate limit hit")
+            _set_rate_limit("jina", cooldown=60)
+            return None
+
+        if response.status_code != 200:
+            logger.warning(f"Jina Reader returned status {response.status_code}")
+            return None
+
+        content = response.text.strip()
+        if not content or len(content) < MIN_CHARS:
+            return None
+
+        result = ResolvedResult(
+            source="jina",
+            content=content[:max_chars],
+            url=url,
+        )
+        _save_to_cache(url, "jina", result.to_dict())
+        return result
+
+    except requests.exceptions.Timeout:
+        logger.warning("Jina Reader request timed out")
+        _set_rate_limit("jina", cooldown=30)
+        return None
+    except Exception as e:
+        logger.error(f"Jina Reader failed: {e}")
+        return None
 
 
 def resolve_with_exa_mcp(
@@ -1259,7 +1400,7 @@ def resolve_with_mistral_websearch(query: str, max_chars: int = MAX_CHARS) -> Re
 
 def resolve_url(url: str, max_chars: int = MAX_CHARS) -> dict[str, Any]:
     """
-    Resolve a URL using the cascade: llms.txt → Firecrawl → Direct fetch → Mistral browser → DuckDuckGo search.
+    Resolve a URL using the cascade: llms.txt → Jina Reader → Firecrawl → Direct fetch → Mistral browser → DuckDuckGo search.
     """
     logger.info(f"Resolving URL: {url}")
 
@@ -1273,22 +1414,27 @@ def resolve_url(url: str, max_chars: int = MAX_CHARS) -> dict[str, Any]:
             "validated_links": [],
         }
 
-    # Step 2: Try Firecrawl (if API key available)
+    # Step 2: Try Jina Reader (FREE, no API key required)
+    jina_result = resolve_with_jina(url, max_chars)
+    if jina_result:
+        return jina_result.to_dict()
+
+    # Step 3: Try Firecrawl (if API key available)
     firecrawl_result = resolve_with_firecrawl(url, max_chars)
     if firecrawl_result:
         return firecrawl_result.to_dict()
 
-    # Step 3: Try direct HTTP fetch
+    # Step 4: Try direct HTTP fetch
     direct_result = fetch_url_content(url, max_chars=max_chars)
     if direct_result:
         return direct_result.to_dict()
 
-    # Step 4: Try Mistral browser (if API key available)
+    # Step 5: Try Mistral browser (if API key available)
     mistral_result = resolve_with_mistral_browser(url, max_chars)
     if mistral_result:
         return mistral_result.to_dict()
 
-    # Step 5: Fall back to DuckDuckGo search for the URL
+    # Step 6: Fall back to DuckDuckGo search for the URL
     ddg_result = resolve_with_duckduckgo(url, max_chars)
     if ddg_result:
         return ddg_result.to_dict()
@@ -1379,6 +1525,311 @@ def resolve(
         return resolve_query(input_str, max_chars, skip_providers)
 
 
+def resolve_direct(
+    input_str: str,
+    provider: ProviderType,
+    max_chars: int = MAX_CHARS,
+) -> dict[str, Any]:
+    """
+    Resolve a URL or query using a specific provider directly.
+
+    Bypasses the cascade and uses only the specified provider.
+    Useful when you know exactly which service you want to use.
+
+    Args:
+        input_str: URL or search query to resolve
+        provider: Specific provider to use (ProviderType enum)
+        max_chars: Maximum characters in output
+
+    Returns:
+        Resolution result dict with 'source', 'content', etc.
+
+    Example:
+        >>> from scripts.resolve import resolve_direct, ProviderType
+        >>> result = resolve_direct("https://example.com", ProviderType.JINA)
+        >>> result = resolve_direct("python tutorials", ProviderType.EXA_MCP)
+    """
+    logger.info(f"Resolving with direct provider: {provider.value}")
+
+    # URL providers
+    if provider == ProviderType.LLMS_TXT:
+        if not is_url(input_str):
+            return {
+                "source": "none",
+                "error": "llms_txt provider requires a URL input",
+                "content": "",
+                "validated_links": [],
+            }
+        llms_content = fetch_llms_txt(input_str)
+        if llms_content:
+            return {
+                "source": "llms.txt",
+                "url": input_str,
+                "content": llms_content[:max_chars],
+                "validated_links": [],
+            }
+        return {
+            "source": "none",
+            "url": input_str,
+            "error": "No llms.txt found at origin",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.JINA:
+        if not is_url(input_str):
+            return {
+                "source": "none",
+                "error": "jina provider requires a URL input",
+                "content": "",
+                "validated_links": [],
+            }
+        result = resolve_with_jina(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "url": input_str,
+            "error": "Jina Reader failed to extract content",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.FIRECRAWL:
+        if not is_url(input_str):
+            return {
+                "source": "none",
+                "error": "firecrawl provider requires a URL input",
+                "content": "",
+                "validated_links": [],
+            }
+        result = resolve_with_firecrawl(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "url": input_str,
+            "error": "Firecrawl failed or API key not set",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.DIRECT_FETCH:
+        if not is_url(input_str):
+            return {
+                "source": "none",
+                "error": "direct_fetch provider requires a URL input",
+                "content": "",
+                "validated_links": [],
+            }
+        result = fetch_url_content(input_str, max_chars=max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "url": input_str,
+            "error": "Direct HTTP fetch failed",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.MISTRAL_BROWSER:
+        if not is_url(input_str):
+            return {
+                "source": "none",
+                "error": "mistral_browser provider requires a URL input",
+                "content": "",
+                "validated_links": [],
+            }
+        result = resolve_with_mistral_browser(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "url": input_str,
+            "error": "Mistral browser failed or API key not set",
+            "content": "",
+            "validated_links": [],
+        }
+
+    # Query providers
+    elif provider == ProviderType.EXA_MCP:
+        result = resolve_with_exa_mcp(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "query": input_str,
+            "error": "Exa MCP search failed",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.EXA:
+        result = resolve_with_exa(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "query": input_str,
+            "error": "Exa SDK search failed or API key not set",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.TAVILY:
+        result = resolve_with_tavily(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "query": input_str,
+            "error": "Tavily search failed or API key not set",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.DUCKDUCKGO:
+        result = resolve_with_duckduckgo(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "query": input_str,
+            "error": "DuckDuckGo search failed",
+            "content": "",
+            "validated_links": [],
+        }
+
+    elif provider == ProviderType.MISTRAL_WEBSEARCH:
+        result = resolve_with_mistral_websearch(input_str, max_chars)
+        if result:
+            return result.to_dict()
+        return {
+            "source": "none",
+            "query": input_str,
+            "error": "Mistral websearch failed or API key not set",
+            "content": "",
+            "validated_links": [],
+        }
+
+    else:
+        return {
+            "source": "none",
+            "error": f"Unknown provider: {provider}",
+            "content": "",
+            "validated_links": [],
+        }
+
+
+def resolve_with_order(
+    input_str: str,
+    providers_order: list[ProviderType],
+    max_chars: int = MAX_CHARS,
+) -> dict[str, Any]:
+    """
+    Resolve a URL or query using a custom provider order.
+
+    Allows overriding the default cascade order. Providers are tried
+    in sequence until one succeeds.
+
+    Args:
+        input_str: URL or search query to resolve
+        providers_order: List of providers to try in order (ProviderType enums)
+        max_chars: Maximum characters in output
+
+    Returns:
+        Resolution result dict with 'source', 'content', etc.
+
+    Example:
+        >>> from scripts.resolve import resolve_with_order, ProviderType
+        >>> # Use only free providers for URLs
+        >>> result = resolve_with_order(
+        ...     "https://example.com",
+        ...     [ProviderType.LLMS_TXT, ProviderType.JINA, ProviderType.DIRECT_FETCH]
+        ... )
+        >>> # Use only free providers for queries
+        >>> result = resolve_with_order(
+        ...     "python tutorials",
+        ...     [ProviderType.EXA_MCP, ProviderType.DUCKDUCKGO]
+        ... )
+    """
+    logger.info(f"Resolving with custom provider order: {[p.value for p in providers_order]}")
+
+    for provider in providers_order:
+        result = resolve_direct(input_str, provider, max_chars)
+        if result.get("source") != "none":
+            return result
+
+    # All providers failed
+    is_url_input = is_url(input_str)
+    return {
+        "source": "none",
+        "url": input_str if is_url_input else None,
+        "query": None if is_url_input else input_str,
+        "content": f"# Unable to resolve {'URL' if is_url_input else 'query'}: {input_str}\n\nAll specified providers failed.\n",
+        "error": "No resolution method available",
+        "validated_links": [],
+    }
+
+
+def resolve_url_with_order(
+    url: str,
+    providers_order: list[ProviderType],
+    max_chars: int = MAX_CHARS,
+) -> dict[str, Any]:
+    """
+    Resolve a URL using a custom provider order.
+
+    Args:
+        url: URL to resolve
+        providers_order: List of URL providers to try in order
+        max_chars: Maximum characters in output
+
+    Returns:
+        Resolution result dict
+    """
+    # Filter to only URL-compatible providers
+    url_providers = {
+        ProviderType.LLMS_TXT,
+        ProviderType.JINA,
+        ProviderType.FIRECRAWL,
+        ProviderType.DIRECT_FETCH,
+        ProviderType.MISTRAL_BROWSER,
+        ProviderType.DUCKDUCKGO,  # Can search for URLs too
+    }
+    valid_providers = [p for p in providers_order if p in url_providers]
+    return resolve_with_order(url, valid_providers, max_chars)
+
+
+def resolve_query_with_order(
+    query: str,
+    providers_order: list[ProviderType],
+    max_chars: int = MAX_CHARS,
+) -> dict[str, Any]:
+    """
+    Resolve a query using a custom provider order.
+
+    Args:
+        query: Search query to resolve
+        providers_order: List of query providers to try in order
+        max_chars: Maximum characters in output
+
+    Returns:
+        Resolution result dict
+    """
+    # Filter to only query-compatible providers
+    query_providers = {
+        ProviderType.EXA_MCP,
+        ProviderType.EXA,
+        ProviderType.TAVILY,
+        ProviderType.DUCKDUCKGO,
+        ProviderType.MISTRAL_WEBSEARCH,
+    }
+    valid_providers = [p for p in providers_order if p in query_providers]
+    return resolve_with_order(query, valid_providers, max_chars)
+
+
 def main():
     """Command-line interface for the resolver."""
     parser = argparse.ArgumentParser(
@@ -1405,6 +1856,17 @@ def main():
         choices=["exa_mcp", "exa", "tavily", "duckduckgo", "mistral"],
         help="Skip specific providers (can be used multiple times). Options: exa_mcp, exa, tavily, duckduckgo, mistral",
     )
+    parser.add_argument(
+        "--provider",
+        type=str,
+        choices=[p.value for p in ProviderType],
+        help="Use a specific provider directly (bypasses cascade). Options: llms_txt, jina, firecrawl, direct_fetch, mistral_browser, exa_mcp, exa, tavily, duckduckgo, mistral_websearch",
+    )
+    parser.add_argument(
+        "--providers-order",
+        type=str,
+        help="Custom provider order (comma-separated). Example: 'llms_txt,jina,direct_fetch' for URLs or 'exa_mcp,duckduckgo' for queries",
+    )
 
     args = parser.parse_args()
 
@@ -1418,10 +1880,33 @@ def main():
 
     skip_providers = set(args.skip) if args.skip else None
 
+    # Parse provider order if specified
+    providers_order = None
+    if args.providers_order:
+        provider_names = [p.strip() for p in args.providers_order.split(",")]
+        try:
+            providers_order = [ProviderType(p) for p in provider_names]
+        except ValueError as e:
+            parser.error(f"Invalid provider in --providers-order: {e}")
+
+    # Parse single provider if specified
+    single_provider = None
+    if args.provider:
+        single_provider = ProviderType(args.provider)
+
+    def process_input(inp: str) -> dict[str, Any]:
+        """Process a single input string."""
+        if single_provider:
+            return resolve_direct(inp, single_provider, args.max_chars)
+        elif providers_order:
+            return resolve_with_order(inp, providers_order, args.max_chars)
+        else:
+            return resolve(inp, args.max_chars, skip_providers)
+
     if args.input == "-":
         inputs = [line.strip() for line in sys.stdin if line.strip()]
         for i, inp in enumerate(inputs):
-            result = resolve(inp, args.max_chars, skip_providers)
+            result = process_input(inp)
             if args.json:
                 print(json.dumps(result, indent=2))
             else:
@@ -1436,7 +1921,7 @@ def main():
             if i < len(inputs) - 1:
                 print("\n" + "=" * 40 + "\n")
     else:
-        result = resolve(args.input, args.max_chars, skip_providers)
+        result = process_input(args.input)
 
         if args.json:
             print(json.dumps(result, indent=2))


### PR DESCRIPTION
## Summary

This PR adds several enhancements to the web-doc-resolver:

### New Features

1. **Jina Reader Provider** (FREE, no API key)
   - New `resolve_with_jina()` function using `r.jina.ai` for URL-to-markdown extraction
   - Inserted as Step 2 in URL cascade (after llms.txt, before Firecrawl)
   - 20 RPM free tier, no authentication required

2. **llms.txt Caching**
   - Cache llms.txt discovery results per origin domain with 1-hour TTL
   - Eliminates redundant HEAD probes to the same domain

3. **Persistent Rate Limits**
   - Rate-limit state persisted to `~/.cache/web-doc-resolver/rate_limits.json`
   - Survives process restarts and re-invocations

4. **Direct Provider Selection**
   - New `ProviderType` enum for all available providers
   - `resolve_direct()` function to use a specific provider directly (bypasses cascade)
   - `resolve_with_order()` function for custom provider cascade order
   - CLI options: `--provider` and `--providers-order`

### Provider Types

**URL providers**: `llms_txt`, `jina`, `firecrawl`, `direct_fetch`, `mistral_browser`, `duckduckgo`

**Query providers**: `exa_mcp`, `exa`, `tavily`, `duckduckgo`, `mistral_websearch`

### Usage Examples

```bash
# Use a specific provider directly
python scripts/resolve.py "https://example.com" --provider jina
python scripts/resolve.py "python tutorials" --provider exa_mcp

# Use a custom provider order
python scripts/resolve.py "https://example.com" --providers-order "llms_txt,jina,direct_fetch"
python scripts/resolve.py "query" --providers-order "exa_mcp,duckduckgo"
```

```python
from scripts.resolve import resolve_direct, resolve_with_order, ProviderType

# Use Jina Reader directly
result = resolve_direct("https://example.com", ProviderType.JINA)

# Use only free providers
result = resolve_with_order(
    "https://example.com",
    [ProviderType.LLMS_TXT, ProviderType.JINA, ProviderType.DIRECT_FETCH]
)
```

## Test Plan

- [x] All 93 existing tests pass
- [x] Ruff linter passes
- [x] Mypy type checking passes
- [x] CLI help shows new options
- [x] Skill symlink validation passes

## Files Changed

- `scripts/resolve.py` - Core implementation
- `requirements.txt` - Added httpx as optional dependency
- `README.md` - Updated documentation
- `AGENTS.md` - Updated agent instructions