### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/scripts/resolve.py
+++ b/scripts/resolve.py
@@ -29,6 +29,7 @@ from dataclasses import asdict, dataclass, field
 from enum import Enum
 from typing import Any
 from urllib.parse import urlparse
+from html.parser import HTMLParser
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -600,9 +601,43 @@ def extract_text_from_html(html: str, base_url: str = "") -> str:
 
     Uses simple regex-based extraction for reliability.
     """
-    # Remove script and style elements
-    html = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
-    html = re.sub(r"<style[^>]*>.*?</style>", "", html, flags=re.DOTALL | re.IGNORECASE)
+    # Remove script and style elements using a tolerant HTML parser
+    class ScriptStyleStripper(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__(convert_charrefs=False)
+            self.result: list[str] = []
+            self._skip_depth = 0
+
+        def handle_starttag(self, tag, attrs):
+            if tag.lower() in ("script", "style"):
+                self._skip_depth += 1
+                return
+            if self._skip_depth == 0:
+                self.result.append(self.get_starttag_text() or "")
+
+        def handle_endtag(self, tag):
+            if tag.lower() in ("script", "style"):
+                if self._skip_depth > 0:
+                    self._skip_depth -= 1
+                return
+            if self._skip_depth == 0:
+                self.result.append(f"</{tag}>")
+
+        def handle_startendtag(self, tag, attrs):
+            if self._skip_depth == 0 and tag.lower() not in ("script", "style"):
+                self.result.append(self.get_starttag_text() or "")
+
+        def handle_data(self, data):
+            if self._skip_depth == 0:
+                self.result.append(data)
+
+        def handle_comment(self, data):
+            if self._skip_depth == 0:
+                self.result.append(f"<!--{data}-->")
+
+    stripper = ScriptStyleStripper()
+    stripper.feed(html)
+    html = "".join(stripper.result)
 
     # Remove comments
     html = re.sub(r"<!--.*?-->", "", html, flags=re.DOTALL)


### PR DESCRIPTION
Potential fix for [https://github.com/d-oit/web-doc-resolver/security/code-scanning/1](https://github.com/d-oit/web-doc-resolver/security/code-scanning/1)

In general, to fix this problem you should avoid trying to fully parse HTML with a regular expression, and either (a) use a proper HTML parser/sanitizer, or (b) at least make the simple regex robust against the common malformed cases browsers accept (e.g., extra attributes or whitespace in end tags). Since we must minimally change the existing functionality and only edit the shown snippet, the best approach is to improve the script/style removal step using a lightweight parser from the standard library rather than relying on brittle regexes.

The single best fix here is to replace the two regex-based removals of `<script>` and `<style>` blocks with a small helper based on `html.parser.HTMLParser`, which already exists in the standard library (no new external dependencies) and will correctly skip everything inside `<script>` and `<style>` tags regardless of strange spacing or invalid end-tags. We can define a local `ScriptStyleStripper` class inside `extract_text_from_html`, feed it the HTML, and use its output (with script/style content removed) as the new `html` value. This preserves downstream behavior (heading/paragraph/list/link conversions) while ensuring that scripts and styles are reliably stripped.

Concretely:
- Inside `extract_text_from_html`, before the current regex removals on lines 603–605, define a small `HTMLParser` subclass that writes text and non-script/style tags but omits all script/style content.
- Use that parser to transform the input `html` string into a cleaned version; assign that back to `html`.
- Remove or bypass the existing `re.sub` calls that try to strip `<script>` and `<style>` with regex.
- No new imports are needed because `html.parser` is part of the standard library; we can import `HTMLParser` at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
