### PR TITLE
fix: patch libsql-sqlite3-parser CVE-2025-47736 (Dependabot alert #1)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,3 +40,9 @@ path = "src/main.rs"
 [lib]
 name = "wdr_lib"
 path = "src/lib.rs"
+
+# Security patch: CVE-2025-47736 / GHSA-8m95-fffc-h4c5
+# libsql-sqlite3-parser <= 0.13.0 crashes on invalid UTF-8 input.
+# No patched release on crates.io yet; pin to the upstream fix commit.
+[patch.crates-io]
+libsql-sqlite3-parser = { git = "https://github.com/tursodatabase/libsql", rev = "14f422a" }


### PR DESCRIPTION
## Security Fix: CVE-2025-47736

Closes Dependabot alert #1: **libsql-sqlite3-parser crash due to invalid UTF-8 input**

- **CVE:** CVE-2025-47736
- **GHSA:** GHSA-8m95-fffc-h4c5
- **Severity:** Low (CVSS 2.9)
- **Affected:** `libsql-sqlite3-parser` <= 0.13.0 (transitive via `chaotic_semantic_memory`)

### What changed

Added a `[patch.crates-io]` override in `cli/Cargo.toml` pointing `libsql-sqlite3-parser` to the upstream fix commit [`14f422a`](https://github.com/tursodatabase/libsql/commit/14f422a), which resolves the UTF-8 crash in `dialect/mod.rs`.

No patched release is available on crates.io yet. Once one is published, this patch block can be removed and the version pin updated instead.

> **Note:** You need to run `cargo update -p libsql-sqlite3-parser` inside `cli/` locally to regenerate `Cargo.lock` with the patched revision.