### PR TITLE
🎨 Palette: History deletion confirmation

### DIFF
--- a/web/app/components/History.tsx
+++ b/web/app/components/History.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 export interface HistoryEntry {
   id: string;
@@ -22,6 +22,8 @@ export default function History({ onLoad }: HistoryProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const deleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchHistory = async () => {
     setLoading(true);
@@ -44,12 +46,35 @@ export default function History({ onLoad }: HistoryProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, search]);
 
+  useEffect(() => {
+    return () => {
+      if (deleteTimeoutRef.current) clearTimeout(deleteTimeoutRef.current);
+    };
+  }, []);
+
   const handleDelete = async (id: string) => {
+    if (confirmDeleteId !== id) {
+      if (deleteTimeoutRef.current) clearTimeout(deleteTimeoutRef.current);
+      setConfirmDeleteId(id);
+      deleteTimeoutRef.current = setTimeout(() => {
+        setConfirmDeleteId(null);
+        deleteTimeoutRef.current = null;
+      }, 3000);
+      return;
+    }
+
     try {
-      await fetch(`/api/history?id=${id}`, { method: "DELETE" });
+      if (deleteTimeoutRef.current) clearTimeout(deleteTimeoutRef.current);
+      const res = await fetch(`/api/history?id=${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Delete failed");
+
       setEntries((prev) => prev.filter((e) => e.id !== id));
+      setConfirmDeleteId(null);
+      deleteTimeoutRef.current = null;
     } catch {
-      // Silent fail
+      // Silent fail but reset state
+      setConfirmDeleteId(null);
+      deleteTimeoutRef.current = null;
     }
   };
 
@@ -107,10 +132,14 @@ export default function History({ onLoad }: HistoryProps) {
                   </div>
                   <button
                     onClick={() => handleDelete(entry.id)}
-                    className="text-[10px] text-[#444] hover:text-[#ff4444] opacity-0 group-hover:opacity-100 transition-opacity min-h-[44px] min-w-[44px] flex items-center justify-center"
-                    aria-label={`Delete ${entry.query}`}
+                    className={`text-[10px] min-h-[44px] min-w-[44px] flex items-center justify-center transition-all ${
+                      confirmDeleteId === entry.id
+                        ? "text-[#ff4444] font-bold"
+                        : "text-[#444] hover:text-[#ff4444] opacity-0 group-hover:opacity-100"
+                    }`}
+                    aria-label={confirmDeleteId === entry.id ? `Confirm delete ${entry.query}` : `Delete ${entry.query}`}
                   >
-                    ×
+                    {confirmDeleteId === entry.id ? "CONFIRM" : "×"}
                   </button>
                 </div>
               ))

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,8 @@
     "next": "^16.2.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",

--- a/web/tests/e2e/history.spec.ts
+++ b/web/tests/e2e/history.spec.ts
@@ -227,7 +227,7 @@ test.describe("History Search", () => {
 
 test.describe("History Delete", () => {
   test("delete button removes entry", async ({ page }) => {
-    let entries = [{
+    const testEntry = {
       id: "test-id-1",
       query: "test entry to delete",
       result: "Test content",
@@ -235,45 +235,46 @@ test.describe("History Delete", () => {
       timestamp: Date.now(),
       charCount: 12,
       resolveTime: 100,
-    }];
+    };
 
-    await page.route("**/api/history**", async (route) => {
+    let entries = [testEntry];
+
+    await page.route("**/api/history*", async (route) => {
       const method = route.request().method();
-      const url = new URL(route.request().url());
-
       if (method === "DELETE") {
-        const id = url.searchParams.get("id");
-        entries = entries.filter(e => e.id !== id);
+        entries = [];
         return route.fulfill({
           status: 200,
-          body: JSON.stringify({ ok: true }),
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true })
         });
       }
-
-      if (method === "GET") {
-        return route.fulfill({
-          status: 200,
-          body: JSON.stringify({ entries }),
-        });
-      }
-
-      return route.fulfill({ status: 200, body: "{}" });
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ entries }),
+      });
     });
 
     await page.goto("/");
     await page.getByRole("button", { name: /History/ }).click();
-    await expect(page.locator("text=test entry to delete")).toBeVisible();
 
-    // Hover over entry to reveal delete button
-    const entryRow = page.locator("div").filter({ hasText: "test entry to delete" }).first();
-    await entryRow.hover();
+    // Should show the entry
+    const entry = page.getByText("test entry to delete");
+    await expect(entry).toBeVisible();
 
-    // Click delete button
-    const deleteButton = page.locator("button[aria-label*='Delete']");
-    await deleteButton.click();
+    // The delete button is revealed on hover, but we can use force click or find it by label
+    await page.getByLabel("Delete test entry to delete").click({ force: true });
+
+    // After first click, it should show "CONFIRM"
+    const confirmButton = page.getByRole("button", { name: "CONFIRM" });
+    await expect(confirmButton).toBeVisible();
+
+    // Click again to confirm
+    await confirmButton.click();
 
     // Entry should be removed
-    await expect(page.locator("text=test entry to delete")).not.toBeVisible();
+    await expect(page.getByText("test entry to delete")).not.toBeVisible();
   });
 });
 


### PR DESCRIPTION
Implemented a two-click confirmation pattern for deleting history entries to prevent accidental data loss.
- Added a 3-second confirmation window before deletion is executed.
- Integrated `useRef` for robust timer management and cleanup.
- Enhanced accessibility with dynamic ARIA labels ("Delete" -> "Confirm delete").
- Updated E2E tests to verify the new interaction flow.
- Added missing `zod` dependency required for validation tests.

---
*PR created automatically by Jules for task [4513099308717737149](https://jules.google.com/task/4513099308717737149) started by @d-oit*