### PR TITLE
Implement robust SSRF protection in Rust CLI

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -19,6 +19,7 @@ pub mod resolver;
 pub mod routing;
 pub mod routing_memory;
 pub mod semantic_cache;
+pub mod ssrf;
 pub mod synthesis;
 pub mod types;
 

--- a/cli/src/link_validator.rs
+++ b/cli/src/link_validator.rs
@@ -1,18 +1,20 @@
 //! Async link validation for research results.
 
+use crate::ssrf::{create_safe_client_builder, is_safe_url};
 use futures::future::join_all;
-use reqwest::Client;
 use std::time::Duration;
 
 /// Validate a list of links using HTTP HEAD requests
 pub async fn validate_links(links: &[String]) -> Vec<String> {
-    let client = Client::builder()
-        .timeout(Duration::from_secs(5))
+    let client = create_safe_client_builder(Duration::from_secs(5))
         .build()
         .unwrap_or_default();
 
     let mut futures = Vec::new();
     for link in links {
+        if !is_safe_url(link) {
+            continue;
+        }
         let client = client.clone();
         let link = link.clone();
         futures.push(tokio::spawn(async move {

--- a/cli/src/providers/direct_fetch.rs
+++ b/cli/src/providers/direct_fetch.rs
@@ -3,11 +3,13 @@
 //! Basic content extraction from HTML.
 
 use crate::error::{ResolverError, detect_error_type};
+use crate::ssrf::create_safe_client_builder;
 use crate::types::ResolvedResult;
 use async_trait::async_trait;
 use std::result::Result;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 /// Direct HTTP fetch provider
 pub struct DirectFetchProvider {
@@ -19,7 +21,9 @@ impl DirectFetchProvider {
     /// Create a new direct fetch provider
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: create_safe_client_builder(Duration::from_secs(10))
+                .build()
+                .unwrap_or_default(),
             rate_limited: Arc::new(AtomicBool::new(false)),
         }
     }

--- a/cli/src/providers/llms_txt.rs
+++ b/cli/src/providers/llms_txt.rs
@@ -3,11 +3,13 @@
 //! Checks for site-provided structured documentation.
 
 use crate::error::{ResolverError, detect_error_type};
+use crate::ssrf::create_safe_client_builder;
 use crate::types::ResolvedResult;
 use async_trait::async_trait;
 use std::result::Result;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 use url::Url;
 
 /// llms.txt provider - checks for structured LLM documentation
@@ -20,7 +22,9 @@ impl LlmsTxtProvider {
     /// Create a new llms.txt provider
     pub fn new() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: create_safe_client_builder(Duration::from_secs(10))
+                .build()
+                .unwrap_or_default(),
             rate_limited: Arc::new(AtomicBool::new(false)),
         }
     }

--- a/cli/src/resolver/cascade.rs
+++ b/cli/src/resolver/cascade.rs
@@ -19,55 +19,7 @@ pub fn extract_domain_or_default(target: &str) -> String {
         .unwrap_or_default()
 }
 
-/// Check if a URL is safe from SSRF attempts.
-pub fn is_safe_url(url_str: &str) -> bool {
-    let parsed = match url::Url::parse(url_str) {
-        Ok(u) => u,
-        Err(_) => return false,
-    };
-
-    let scheme = parsed.scheme().to_lowercase();
-    if scheme != "http" && scheme != "https" {
-        return false;
-    }
-
-    let host = match parsed.host() {
-        Some(h) => h,
-        None => return false,
-    };
-
-    match host {
-        url::Host::Domain(domain) => {
-            let lowered = domain.to_lowercase();
-            if lowered == "localhost"
-                || lowered == "localhost.localdomain"
-                || lowered.ends_with(".local")
-                || lowered.ends_with(".internal")
-            {
-                return false;
-            }
-            true
-        }
-        url::Host::Ipv4(ip) => !is_private_ipv4(ip),
-        url::Host::Ipv6(ip) => !is_private_ipv6(ip),
-    }
-}
-
-fn is_private_ipv4(ip: std::net::Ipv4Addr) -> bool {
-    ip.is_loopback()
-        || ip.is_private()
-        || ip.is_link_local()
-        || ip.is_documentation()
-        || ip.is_broadcast()
-        || ip.is_unspecified()
-}
-
-fn is_private_ipv6(ip: std::net::Ipv6Addr) -> bool {
-    ip.is_loopback()
-        || ip.is_unspecified()
-        || (ip.segments()[0] & 0xfe00) == 0xfc00
-        || (ip.segments()[0] & 0xffc0) == 0xfe80
-}
+pub use crate::ssrf::is_safe_url;
 
 /// Classify error type for routing decisions
 pub fn classify_error(err: &ResolverError) -> String {
@@ -117,17 +69,6 @@ mod tests {
             "example.com"
         );
         assert_eq!(extract_domain_or_default("not a url"), "");
-    }
-
-    #[test]
-    fn test_is_safe_url() {
-        assert!(is_safe_url("https://example.com"));
-        assert!(is_safe_url("http://example.com/path"));
-        assert!(!is_safe_url("http://localhost"));
-        assert!(!is_safe_url("http://127.0.0.1"));
-        assert!(!is_safe_url("http://[::1]"));
-        assert!(!is_safe_url("http://192.168.0.1"));
-        assert!(!is_safe_url("file:///etc/passwd"));
     }
 
     #[test]

--- a/cli/src/ssrf.rs
+++ b/cli/src/ssrf.rs
@@ -1,0 +1,85 @@
+//! SSRF protection utilities.
+
+use reqwest::redirect::Policy;
+use std::time::Duration;
+use url::Url;
+
+/// Check if a URL is safe from SSRF attempts.
+pub fn is_safe_url(url_str: &str) -> bool {
+    let parsed = match Url::parse(url_str) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+
+    let scheme = parsed.scheme().to_lowercase();
+    if scheme != "http" && scheme != "https" {
+        return false;
+    }
+
+    let host = match parsed.host() {
+        Some(h) => h,
+        None => return false,
+    };
+
+    match host {
+        url::Host::Domain(domain) => {
+            let lowered = domain.to_lowercase();
+            if lowered == "localhost"
+                || lowered == "localhost.localdomain"
+                || lowered.ends_with(".local")
+                || lowered.ends_with(".internal")
+            {
+                return false;
+            }
+            true
+        }
+        url::Host::Ipv4(ip) => !is_private_ipv4(ip),
+        url::Host::Ipv6(ip) => !is_private_ipv6(ip),
+    }
+}
+
+fn is_private_ipv4(ip: std::net::Ipv4Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_private()
+        || ip.is_link_local()
+        || ip.is_documentation()
+        || ip.is_broadcast()
+        || ip.is_unspecified()
+}
+
+fn is_private_ipv6(ip: std::net::Ipv6Addr) -> bool {
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || (ip.segments()[0] & 0xfe00) == 0xfc00
+        || (ip.segments()[0] & 0xffc0) == 0xfe80
+}
+
+/// Create a reqwest ClientBuilder with SSRF protection via redirect policy.
+pub fn create_safe_client_builder(timeout: Duration) -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .redirect(Policy::custom(|attempt| {
+            let url = attempt.url().as_str();
+            if is_safe_url(url) {
+                attempt.follow()
+            } else {
+                attempt.stop()
+            }
+        }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_safe_url() {
+        assert!(is_safe_url("https://example.com"));
+        assert!(is_safe_url("http://example.com/path"));
+        assert!(!is_safe_url("http://localhost"));
+        assert!(!is_safe_url("http://127.0.0.1"));
+        assert!(!is_safe_url("http://[::1]"));
+        assert!(!is_safe_url("http://192.168.0.1"));
+        assert!(!is_safe_url("file:///etc/passwd"));
+    }
+}


### PR DESCRIPTION
Implemented robust SSRF protection in the Rust CLI by centralizing safety checks and enforcing redirect validation. Created a new `ssrf` module in the CLI source to handle private IP and hostname filtering, and utilized a custom `reqwest` redirect policy to prevent bypasses via malicious redirects. Updated all direct fetchers and the link validator to use this secured client.

---
*PR created automatically by Jules for task [9954212071763424229](https://jules.google.com/task/9954212071763424229) started by @d-oit*