### PR TITLE
Implement Redirect-Aware SSRF Protection in Web UI

### DIFF
--- a/web/lib/resolvers/url.ts
+++ b/web/lib/resolvers/url.ts
@@ -1,17 +1,54 @@
 import { Logger } from "@/lib/log";
+import { validateUrl } from "@/lib/validation";
 
 export const MAX_CHARS = parseInt(process.env.WEB_RESOLVER_MAX_CHARS || "8000");
 export const MIN_CHARS = parseInt(process.env.WEB_RESOLVER_MIN_CHARS || "50");
 
-async function fetchWithTimeout(
+async function safeFetch(
   url: string,
   options: RequestInit,
-  timeoutMs = 15000
+  timeoutMs = 15000,
+  maxRedirects = 5
 ): Promise<Response> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let currentUrl = url;
+
   try {
-    return await fetch(url, { ...options, signal: controller.signal });
+    for (let i = 0; i <= maxRedirects; i++) {
+      // Validate the URL for SSRF before each fetch (including the first hop)
+      const validation = validateUrl(currentUrl);
+      if (!validation.valid) {
+        throw new Error(`SSRF blocked: ${validation.error || "Unsafe URL"}`);
+      }
+
+      const res = await fetch(currentUrl, {
+        ...options,
+        redirect: "manual",
+        signal: controller.signal,
+      });
+
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get("location");
+        if (!location) return res;
+
+        // Construct absolute URL for the next hop
+        const nextUrl = new URL(location, currentUrl).toString();
+
+        // Validate the redirect target for SSRF
+        const validation = validateUrl(nextUrl);
+        if (!validation.valid) {
+          throw new Error(`SSRF blocked: ${validation.error || "Unsafe redirect"}`);
+        }
+
+        currentUrl = nextUrl;
+        continue;
+      }
+
+      return res;
+    }
+    throw new Error("Too many redirects");
   } finally {
     clearTimeout(timer);
   }
@@ -23,7 +60,7 @@ export async function extractViaLlmsTxt(url: string, log: Logger): Promise<strin
   try {
     const parsed = new URL(url);
     const llmsUrl = `${parsed.origin}/llms.txt`;
-    const res = await fetchWithTimeout(llmsUrl, {
+    const res = await safeFetch(llmsUrl, {
       headers: { Accept: "text/plain" },
     }, 8000);
     if (!res.ok) {
@@ -47,7 +84,7 @@ export async function extractViaJina(url: string, log: Logger): Promise<string |
   const start = Date.now();
   log.info("attempt", "jina", { url });
   try {
-    const res = await fetchWithTimeout(`https://r.jina.ai/${url}`, {
+    const res = await safeFetch(`https://r.jina.ai/${url}`, {
       headers: { Accept: "text/plain", "X-Return-Format": "text" },
     });
     if (!res.ok) {
@@ -70,7 +107,7 @@ export async function extractViaDirectFetch(url: string, log: Logger): Promise<s
   const start = Date.now();
   log.info("attempt", "direct_fetch", { url });
   try {
-    const res = await fetchWithTimeout(url, {
+    const res = await safeFetch(url, {
       headers: {
         "User-Agent": "Mozilla/5.0 (compatible; WebDocResolver/2.0)",
         Accept: "text/html",
@@ -103,7 +140,7 @@ export async function extractViaFirecrawl(url: string, apiKey: string, log: Logg
   const start = Date.now();
   log.info("attempt", "firecrawl", { url });
   try {
-    const res = await fetchWithTimeout(
+    const res = await safeFetch(
       "https://api.firecrawl.dev/v1/scrape",
       {
         method: "POST",
@@ -137,7 +174,7 @@ export async function extractViaMistralBrowser(url: string, apiKey: string, log:
   const start = Date.now();
   log.info("attempt", "mistral_browser", { url });
   try {
-    const res = await fetchWithTimeout(
+    const res = await safeFetch(
       "https://api.mistral.ai/v1/chat/completions",
       {
         method: "POST",

--- a/web/lib/validation.ts
+++ b/web/lib/validation.ts
@@ -6,21 +6,28 @@ const MAX_URL_LENGTH = 2048;
 
 // Private IP ranges for SSRF protection
 const PRIVATE_IP_RANGES = [
-  /^127\./,
-  /^10\./,
-  /^172\.(1[6-9]|2[0-9]|3[0-1])\./,
-  /^192\.168\./,
-  /^169\.254\./,
-  /^::1$/,
-  /^fc/i,
-  /^fd/i,
-  /^fe80/i,
-  /^0\.0\.0\.0$/,
+  /^127\./, // IPv4 loopback
+  /^10\./, // RFC1918
+  /^172\.(1[6-9]|2[0-9]|3[0-1])\./, // RFC1918
+  /^192\.168\./, // RFC1918
+  /^169\.254\./, // IPv4 link-local
+  /^100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\./, // CGNAT (100.64.0.0/10)
+  /^::1$/, // IPv6 loopback
+  /^::ffff:0:0:0:0:/i, // IPv4-mapped IPv6 (::ffff:0.0.0.0/96)
+  /^::ffff:[0-9.]+$/i, // Alternative IPv4-mapped IPv6
+  /^::$/, // Unspecified address
+  /^fc/i, // Unique local address (fc00::/7)
+  /^fd/i, // Unique local address (fc00::/7)
+  /^fe80/i, // Link-local address (fe80::/10)
+  /^2001:0*db8:/i, // Documentation (2001:db8::/32)
+  /^0\.0\.0\.0$/, // All interfaces
   /^localhost$/i,
 ];
 
 function isPrivateIp(hostname: string): boolean {
-  return PRIVATE_IP_RANGES.some((range) => range.test(hostname));
+  // Strip square brackets for IPv6 addresses
+  const normalized = hostname.replace(/^\[|\]$/g, "");
+  return PRIVATE_IP_RANGES.some((range) => range.test(normalized));
 }
 
 function isBlockedInternalHostname(hostname: string): boolean {

--- a/web/tests/validation.test.ts
+++ b/web/tests/validation.test.ts
@@ -52,11 +52,16 @@ describe("validateUrl", () => {
       "http://10.0.0.1/test",
       "http://192.168.1.1/test",
       "http://172.16.0.1/test",
+      "http://169.254.169.254/latest/meta-data/",
+      "http://100.64.0.1/test", // CGNAT
+      "http://[::1]/test", // IPv6 loopback
+      "http://[fc00::1]/test", // ULA
+      "http://[fe80::1]/test", // Link-local
     ];
 
     for (const url of privateUrls) {
       const result = validateUrl(url);
-      expect(result.valid).toBe(false);
+      expect(result.valid).toBe(false, `Expected ${url} to be invalid`);
     }
   });
 


### PR DESCRIPTION
This PR addresses a critical security gap in the Web UI where SSRF protection did not account for malicious redirects to internal or private IP ranges. 

Key enhancements:
1. **Manual Redirect Validation**: Replaced automatic redirect following in `fetch` with a `safeFetch` utility that inspects every hop (including the first) using `validateUrl`.
2. **Robust IP Filtering**: Expanded the blacklist of private IP ranges in `web/lib/validation.ts` to include CGNAT (100.64.0.0/10), IPv4-mapped IPv6, and documentation ranges.
3. **Defense-in-Depth**: Integrated `validateUrl` into the core fetching logic of all URL providers (`llms_txt`, `jina`, `direct_fetch`, etc.).
4. **IPv6 Support**: Improved IPv6 hostname handling by properly stripping square brackets before regex validation.

These changes measurably improve the application's security posture by preventing attackers from probing internal infrastructure via the resolver.

---
*PR created automatically by Jules for task [8594028084432376815](https://jules.google.com/task/8594028084432376815) started by @d-oit*