### PR TITLE
[Follow-up] fix: remove stale DNS caching from SSRF hostname checks

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -9,7 +9,6 @@ import os
 import re
 import socket
 from concurrent.futures import ThreadPoolExecutor
-from functools import lru_cache
 from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse
@@ -53,9 +52,8 @@ _global_session: requests.Session | None = None
 _cache = None
 
 
-@lru_cache(maxsize=1024)
-def _getaddrinfo_cached(hostname: str) -> list[tuple]:
-    """Cached version of socket.getaddrinfo to avoid redundant DNS lookups."""
+def _getaddrinfo_uncached(hostname: str) -> list[tuple]:
+    """Resolve DNS records without process-wide caching for SSRF safety checks."""
     return socket.getaddrinfo(hostname, None)
 
 
@@ -159,7 +157,7 @@ def is_safe_url(url: str) -> bool:
                 return False
         except ValueError:
             try:
-                infos = _getaddrinfo_cached(hostname)
+                infos = _getaddrinfo_uncached(hostname)
                 for _family, _socktype, _proto, _canonname, sockaddr in infos:
                     ip = ipaddress.ip_address(sockaddr[0])
                     if any(ip in network for network in BLOCKED_NETWORKS):


### PR DESCRIPTION
### Motivation
- Prevent stale DNS answers from being reused in long-lived processes so SSRF hostname checks remain accurate by performing fresh DNS resolution for each validation.

### Description
- Removed the `lru_cache` usage and replaced the cached helper with `_getaddrinfo_uncached` in `scripts/utils.py`, and updated `is_safe_url` to call `_getaddrinfo_uncached` so `socket.getaddrinfo` is invoked on each check.

### Testing
- Ran the non-live Python test suite with `python -m pytest tests/ -v -m "not live"`, which completed successfully (`153 passed, 15 skipped`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd15a1e41c832bb40711c12137c65e)