### PR TITLE
feat(ux): add clear search button and auto-focus to history

### DIFF
--- a/web/app/components/History.tsx
+++ b/web/app/components/History.tsx
@@ -31,6 +31,13 @@ export default function History({ onLoad }: HistoryProps) {
   const [loading, setLoading] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const deleteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      searchInputRef.current?.focus();
+    }
+  }, [isOpen]);
 
   const fetchHistory = async () => {
     setLoading(true);
@@ -105,13 +112,28 @@ export default function History({ onLoad }: HistoryProps) {
       {isOpen && (
         <div id="history-panel" className="px-4 pb-4">
           {/* Search */}
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search history..."
-            className="w-full bg-[#141414] border-2 border-[#333] px-2 py-2 text-[11px] text-[#e8e6e3] placeholder:text-[#444] focus:border-[#00ff41] focus:outline-none mb-2 min-h-[44px]"
-          />
+          <div className="relative mb-2">
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search history..."
+              className="w-full bg-[#141414] border-2 border-[#333] pl-2 pr-10 py-2 text-[11px] text-[#e8e6e3] placeholder:text-[#444] focus:border-[#00ff41] focus:outline-none min-h-[44px]"
+            />
+            {search && (
+              <button
+                onClick={() => {
+                  setSearch("");
+                  searchInputRef.current?.focus();
+                }}
+                className="absolute right-0 top-0 h-full w-10 flex items-center justify-center text-[#666] hover:text-[#00ff41] focus:text-[#00ff41] focus:outline-none"
+                aria-label="Clear search"
+              >
+                ✕
+              </button>
+            )}
+          </div>
 
           {/* List */}
           <div className="max-h-[320px] overflow-y-auto flex flex-col gap-2">

--- a/web/tests/e2e/history-clear.spec.ts
+++ b/web/tests/e2e/history-clear.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('History Search Clear', () => {
+  test.beforeEach(async ({ page }) => {
+    // Need to set a history entry first or just open the panel
+    await page.goto('/');
+    // Open history panel
+    const historyToggle = page.getByTestId('app-loaded').getByRole('button', { name: /History/i });
+    await historyToggle.click();
+  });
+
+  test('should show clear button when typing in search', async ({ page }) => {
+    const searchInput = page.getByPlaceholder('Search history...');
+    await searchInput.fill('test');
+
+    const clearButton = page.getByLabel('Clear search');
+    await expect(clearButton).toBeVisible();
+  });
+
+  test('should clear search and refocus input when clicking clear button', async ({ page }) => {
+    const searchInput = page.getByPlaceholder('Search history...');
+    await searchInput.fill('test');
+
+    const clearButton = page.getByLabel('Clear search');
+    await clearButton.click();
+
+    await expect(searchInput).toHaveValue('');
+    await expect(searchInput).toBeFocused();
+    await expect(clearButton).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Implemented a micro-UX improvement for the History panel. The search input now automatically focuses when the panel is expanded, and a 'Clear search' button (✕) has been added to streamline the filter-reset workflow. The button only appears when text is present and refocuses the input upon being clicked. A new E2E test suite was added to ensure these behaviors are maintained.

---
*PR created automatically by Jules for task [11755822672785928552](https://jules.google.com/task/11755822672785928552) started by @d-oit*