### PR TITLE
ci: prevent grouped npm major update regressions

### DIFF
--- a/.agents/skills/do-github-pr-sentinel/references/heuristics.md
+++ b/.agents/skills/do-github-pr-sentinel/references/heuristics.md
@@ -9,6 +9,7 @@ Treat as **branch-related** when logs clearly indicate a regression caused by th
 - Snapshot output changes caused by UI/text changes in the branch
 - Static analysis violations introduced by the latest push
 - Build script/config changes in the PR causing a deterministic failure
+- Grouped dependency PRs that upgrade multiple npm packages across major versions, especially `next`, `react`, `eslint`, `eslint-config-next`, `typescript`, `vitest`, or `playwright`
 
 Treat as **likely flaky or unrelated** when evidence points to transient or external issues:
 
@@ -17,6 +18,8 @@ Treat as **likely flaky or unrelated** when evidence points to transient or exte
 - GitHub Actions infrastructure/service outages
 - Cloud/service rate limits or transient API outages
 - Non-deterministic failures in unrelated integration tests with known flake patterns
+
+Do not spend flaky-retry budget on deterministic dependency compatibility failures. Split the dependency set or pin the incompatible upgrade instead.
 
 If uncertain, inspect failed logs once before choosing rerun.
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "python"
+      - "infra"
     groups:
       python-deps:
         patterns:
@@ -34,7 +34,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "rust"
+      - "infra"
     groups:
       cargo-deps:
         patterns:
@@ -54,11 +54,14 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "javascript"
+      - "frontend"
     groups:
       npm-deps:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "build(deps)"
       include: "scope"
@@ -74,11 +77,14 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "javascript"
+      - "frontend"
     groups:
       npm-packages-deps:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "build(deps)"
       include: "scope"
@@ -94,7 +100,8 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "github-actions"
+      - "github_actions"
+      - "ci"
     groups:
       github-actions:
         patterns:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,10 @@ cd web && npx playwright test --project=desktop
 - Errors via `thiserror`, propagation via `anyhow`
 
 ### Web (Next.js)
-- Next.js 15 + React 19, Tailwind CSS v4, TypeScript strict mode
+- Next.js 16 + React 19, Tailwind CSS v4, TypeScript strict mode
 - Playwright for E2E tests (`web/tests/e2e/`)
 - Deployment via Vercel Git integration (push to `main`)
+- Treat grouped npm major updates as high-risk; land them as isolated PRs only after `cd web && npm run lint && npm run build` passes.
 
 ## Repository structure
 
@@ -67,6 +68,7 @@ cd web && npx playwright test --project=desktop
 | Releases | [`agents-docs/RELEASES.md`](agents-docs/RELEASES.md) |
 | Assets & Screenshots | [`agents-docs/ASSETS.md`](agents-docs/ASSETS.md) |
 | Project overview | [`agents-docs/OVERVIEW.md`](agents-docs/OVERVIEW.md) |
+| CI triage heuristics | [`.agents/skills/do-github-pr-sentinel/references/heuristics.md`](.agents/skills/do-github-pr-sentinel/references/heuristics.md) |
 
 ## Skills
 

--- a/agents-docs/DEVELOPMENT.md
+++ b/agents-docs/DEVELOPMENT.md
@@ -98,6 +98,13 @@ npm run build
 npx playwright test --project=desktop
 ```
 
+### Dependency Update Policy
+
+- Treat grouped npm major bumps as compatibility work, not routine maintenance.
+- Keep npm `major` updates isolated so CI failures point to one package family at a time.
+- For any web dependency PR, validate `cd web && npm run lint && npm run build` before merge.
+- If a grouped dependency PR fails deterministically, fix or split the dependency set instead of spending flaky-retry budget on CI reruns.
+
 ## Testing
 
 ### Test Categories
@@ -266,6 +273,11 @@ curl -X PATCH "https://api.vercel.com/v9/projects/{PROJECT_ID}?teamId={TEAM_ID}"
   -d '{"rootDirectory":"web"}'
 ```
 Do NOT use `rootDirectory` in a root `vercel.json` — it's not valid there. The setting must be on the Vercel project.
+
+### Dependency Compatibility Triage
+- PR #224 showed that grouped npm major updates can surface upstream incompatibilities rather than repo code regressions.
+- `eslint-config-next@16.2.3` currently fails under `eslint@10`, so keep ESLint on `^9.39.4` until the Next.js lint stack supports the new major.
+- Evaluate `typescript@6` separately from lint-stack upgrades so type and tooling changes do not get conflated in one PR.
 
 ### E2E Test Reliability
 - Use `data-testid` attributes for Playwright selectors instead of text-based filters


### PR DESCRIPTION
## Summary
- prevent Dependabot from grouping npm major updates for `/web` and `/packages` so incompatible toolchain bumps land in isolated PRs
- align Dependabot labels with the repository's actual label set to remove existing configuration warnings
- document the dependency-compatibility triage rules in `AGENTS.md`, `agents-docs/DEVELOPMENT.md`, and the PR sentinel heuristics reference

## Testing
- not run (configuration and documentation changes only)