### PR TITLE
chore: prepare v0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-04-21
+
+### Added
+
+- **Security**: Comprehensive SSRF hardening across Python, Web UI, and Rust CLI with DNS-aware validation and redirect tracking.
+- **Security**: DNS caching for SSRF validation with LRU cache and time-bucketing to reduce redundant lookups.
+- **Performance**: Optimized `score_content` by caching lowercased text to avoid repeated string operations.
+- **UX**: History panel auto-focus, clear button, and accessible contrast improvements.
+- **UX**: Keyboard accessibility improvements with enhanced focus indicators across the UI.
+- **Providers**: DuckDuckGo deprioritized in cascade due to reliability issues (CAPTCHA/rate limiting).
+- **CLI**: Optimized Rust semantic cache with hardened SSRF protection in HTTP client.
+
+### Changed
+
+- **Dependencies**: Update patched Rust transitive dependencies including `rustls-webpki` and `rand`.
+- **Dependencies**: Update npm dependencies in `/web` with security patches.
+- **Dependencies**: Update GitHub Actions to latest versions.
+- **UI**: Improve dark theme contrast and accessibility across components.
+- **UI**: Sidebar improvements with "Show" text, Keys link, and profile status display.
+- **CI**: Prevent grouped npm major Dependabot update regressions with isolated PR workflow.
+
+### Fixed
+
+- **E2E**: Fix sidebar toggle, profile status, and Keys link locators for Playwright tests.
+- **CLI**: Fix semantic cache benchmark compilation with updated API signatures.
+- **Providers**: Fix ruff lint errors in provider diagnostics script.
+
+### Known Issues
+
+- The optional `semantic-cache` feature still pulls an upstream-constrained `chaotic_semantic_memory -> libsql` dependency chain that keeps several Rust security alerts open.
+- Upstream tracking issue: `d-o-hub/chaotic_semantic_memory#88`.
+
 ## [0.3.1] - 2026-04-20
 
 ### Changed

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "do-wdr"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.85"
 description = "Web Documentation Resolver CLI"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "do-web-doc-resolver"
-version = "0.3.1"
+version = "0.3.2"
 description = "Resolve queries or URLs into compact, LLM-ready markdown using a low-cost cascade"
 readme = "README.md"
 license = {text = "MIT"}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "do-web-doc-resolver-ui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepares the next patch release (v0.3.2) following v0.3.1 which was released on 2026-03-29.

## Version Changes

| File | Before | After |
|---|---|---|
| pyproject.toml | 0.3.1 | 0.3.2 |
| cli/Cargo.toml | 0.3.1 | 0.3.2 |
| web/package.json | 0.3.1 | 0.3.2 |
| CHANGELOG.md | [0.3.1] | [0.3.2] |

## Changes Included

- SSRF hardening across Python, Web UI, and Rust CLI
- DNS caching for SSRF validation
- Performance optimization for score_content
- Keyboard accessibility improvements
- DuckDuckGo deprioritization
- Semantic cache optimization
- Dependency updates
- E2E test fixes

## Test plan

- [x] All version files updated consistently to 0.3.2
- [ ] CI passes
- [ ] Squash merge to main
- [ ] Create GitHub release v0.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)