### PR TITLE
fix(cache): update deprecated sentence-transformers API

### DIFF
--- a/.agents/skills/do-web-doc-resolver/references/CONFIG.md
+++ b/.agents/skills/do-web-doc-resolver/references/CONFIG.md
@@ -192,6 +192,26 @@ Blocked schemes:
 - `data:`
 - `vbscript:`
 
+## Known Issues
+
+### Semantic Cache (#251)
+
+Python semantic cache may fail to retrieve stored results due to sqlite-vec vec0 insert syntax.
+
+**Workaround**: Disable with environment variable:
+```bash
+DO_WDR_SEMANTIC_CACHE=0
+```
+
+### Deprecated API (#252)
+
+`sentence_transformers.SentenceTransformer.get_sentence_embedding_dimension()` is deprecated.
+Use `get_embedding_dimension()` instead.
+
+### Rust Security Alerts (#253)
+
+The optional `semantic-cache` Cargo feature has upstream security alerts. Avoid in production.
+
 ## Logging
 
 ### Log Levels

--- a/.agents/skills/do-web-doc-resolver/references/PROVIDERS.md
+++ b/.agents/skills/do-web-doc-resolver/references/PROVIDERS.md
@@ -248,6 +248,27 @@ AI-powered web search via Mistral.
 - Paid only
 - Higher latency
 
+## Known Issues
+
+### DuckDuckGo Provider (#254)
+
+The `duckduckgo_search` Python package has been renamed to `ddgs`.
+
+**Symptom**: Import errors after dependency update.
+
+**Fix**: Update import in provider implementation:
+```python
+# Old
+from duckduckgo_search import DDGS
+
+# New
+from ddgs import DDGS
+```
+
+### DuckDuckGo Reliability
+
+DuckDuckGo is deprioritized in the cascade due to frequent CAPTCHA/rate limiting issues. It serves as a fallback only.
+
 ## Rate Limits
 
 | Provider | Rate Limit | Notes |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,32 @@ cd web && npx playwright test --project=desktop
 | Project overview | [`agents-docs/OVERVIEW.md`](agents-docs/OVERVIEW.md) |
 | CI triage heuristics | [`.agents/skills/do-github-pr-sentinel/references/heuristics.md`](.agents/skills/do-github-pr-sentinel/references/heuristics.md) |
 
+## Known Issues
+
+See [CHANGELOG.md](CHANGELOG.md) for current known issues:
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#251](https://github.com/d-oit/do-web-doc-resolver/issues/251) | Python semantic cache sqlite-vec compatibility | Open |
+| [#252](https://github.com/d-oit/do-web-doc-resolver/issues/252) | Deprecated `get_sentence_embedding_dimension` API | Fixed |
+| [#253](https://github.com/d-oit/do-web-doc-resolver/issues/253) | Rust semantic-cache security alerts (upstream) | Open |
+| [#255](https://github.com/d-oit/do-web-doc-resolver/issues/255) | Dependabot vulnerabilities pending review | Open |
+| [#256](https://github.com/d-oit/do-web-doc-resolver/issues/256) | Release workflow out-of-order merge handling | Open |
+
+### Semantic Cache Workaround
+
+Disable semantic cache in CI/tests:
+```bash
+DO_WDR_SEMANTIC_CACHE=0 python -m pytest tests/ -v -m "not live"
+```
+
+### Issue Resolution Workflow
+
+**Full workflow before closing issues:**
+1. Apply fix → 2. Dogfood/test → 3. Atomic commit → 4. Push → 5. PR → 6. CI must pass → 7. Merge → 8. Close issue → 9. Update docs/memory
+
+**Do NOT close issues early.** An unmerged fix is not a fixed issue.
+
 ## Skills
 
 | Skill | Location | Description |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Known Issues
 
 - **Semantic Cache**: Python semantic cache tests failing due to sqlite-vec compatibility issues. Temporarily disabled in release workflow. See [Issue #251](https://github.com/d-oit/do-web-doc-resolver/issues/251).
-- **Semantic Cache**: Deprecated `get_sentence_embedding_dimension` API method needs update. See [Issue #252](https://github.com/d-oit/do-web-doc-resolver/issues/252).
+- **Semantic Cache**: Deprecated `get_sentence_embedding_dimension` API fixed. Changed to `get_embedding_dimension` for sentence-transformers 5.x compatibility.
 - **Security**: The optional `semantic-cache` feature pulls an upstream-constrained `chaotic_semantic_memory -> libsql` dependency chain with open Rust security alerts. See [Issue #253](https://github.com/d-oit/do-web-doc-resolver/issues/253).
 - **Security**: 5 Dependabot security vulnerabilities (1 moderate, 4 low) pending review. See [Issue #255](https://github.com/d-oit/do-web-doc-resolver/issues/255).
 

--- a/README.md
+++ b/README.md
@@ -496,6 +496,18 @@ Screenshots and visual assets are stored in `assets/screenshots/`. See [assets/R
 ./scripts/capture/capture-responsive.sh
 ```
 
+## Known Issues
+
+| Issue | Description | Workaround/Fix |
+|-------|-------------|----------------|
+| [#251](https://github.com/d-oit/do-web-doc-resolver/issues/251) | Python semantic cache sqlite-vec vec0 insert syntax | Disable with `DO_WDR_SEMANTIC_CACHE=0` |
+| [#252](https://github.com/d-oit/do-web-doc-resolver/issues/252) | Deprecated `get_sentence_embedding_dimension` API | **Fixed** in `scripts/semantic_cache.py:180` |
+| [#253](https://github.com/d-oit/do-web-doc-resolver/issues/253) | Rust semantic-cache feature security alerts | Avoid `semantic-cache` feature; track upstream `chaotic_semantic_memory#88` |
+| [#255](https://github.com/d-oit/do-web-doc-resolver/issues/255) | Dependabot vulnerabilities (1 moderate, 4 low) | Pending review |
+| [#256](https://github.com/d-oit/do-web-doc-resolver/issues/256) | Release workflow squash merge resets versions | Re-apply version bumps after out-of-order merges |
+
+For detailed tracking, see [CHANGELOG.md](CHANGELOG.md).
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/agents-docs/DEVELOPMENT.md
+++ b/agents-docs/DEVELOPMENT.md
@@ -262,6 +262,87 @@ cargo flamegraph --bin do-wdr -- resolve "query"
 3. Run tests to isolate issue
 4. Check provider status pages
 
+## Known Issues
+
+### Python Semantic Cache (#251)
+
+The sqlite-vec vec0 virtual table insert syntax is causing cache retrieval failures.
+
+**Symptom**: `query()` returns None even after `store()` succeeds.
+
+**Workaround**: Disable semantic cache in tests:
+```bash
+DO_WDR_SEMANTIC_CACHE=0 python -m pytest tests/ -v -m "not live"
+```
+
+**Investigation needed**: Verify vec0 schema and insert syntax compatibility with sqlite-vec 0.1.9.
+
+### Deprecated sentence-transformers API (#252)
+
+The `get_sentence_embedding_dimension()` method was deprecated in sentence-transformers 5.x.
+
+**Location**: `scripts/semantic_cache.py:180`
+
+**Status**: **Fixed** - Changed to `get_embedding_dimension()`.
+
+### Rust semantic-cache security alerts (#253)
+
+The optional `semantic-cache` feature pulls an upstream-constrained dependency chain with open Rust security alerts.
+
+**Affected**: `chaotic_semantic_memory -> libsql` dependency chain
+
+**Workaround**: Do not enable `semantic-cache` feature in production.
+
+**Tracking**: Upstream issue `d-o-hub/chaotic_semantic_memory#88`
+
+### DuckDuckGo package renamed
+
+The `duckduckgo_search` package is now `ddgs`. Update `requirements.txt` when updating dependencies.
+
+## Issue Resolution Workflow
+
+**Full workflow before closing GitHub issues:**
+
+1. **Apply fix** - Make code changes
+2. **Dogfood/test** - Run the actual feature/code to verify it works locally
+3. **Atomic commit** - Single focused commit with conventional commit message
+4. **Push branch** - Push to remote
+5. **Create PR** - Open pull request
+6. **Wait for CI** - All GitHub Actions must pass
+7. **Merge PR** - Merge after CI green
+8. **Close issue** - Only after merge is complete
+9. **Update learnings** - Document what was learned in memory/CHANGELOG
+
+**Do NOT close issues early.** An unmerged fix is not a fixed issue.
+
+Example workflow:
+```bash
+# 1-2. Apply fix and test locally
+python -c "from scripts.semantic_cache import SemanticCache; ..."
+
+# 3. Atomic commit
+git add scripts/semantic_cache.py
+git commit -m "fix(cache): update deprecated sentence-transformers API"
+
+# 4. Push
+git push origin fix-semantic-cache-api
+
+# 5. Create PR
+gh pr create --title "Fix deprecated API" --body "Closes #252"
+
+# 6. Wait for CI (use do-github-pr-sentinel skill)
+gh pr checks <number> --watch
+
+# 7. Merge after green
+gh pr merge <number> --squash
+
+# 8. Close issue (with evidence)
+gh issue close 252 --comment "Verified, merged, CI passed."
+
+# 9. Update docs/memory
+# Edit CHANGELOG.md, AGENTS.md, etc.
+```
+
 ## Lessons Learned
 
 ### Vercel Monorepo Setup

--- a/scripts/semantic_cache.py
+++ b/scripts/semantic_cache.py
@@ -177,7 +177,7 @@ class SemanticCache:
 
                 logger.info(f"Loading sentence-transformers model: {self._model_name}")
                 self._model = SentenceTransformer(self._model_name)
-                self._embedding_dimension = self._model.get_sentence_embedding_dimension()
+                self._embedding_dimension = self._model.get_embedding_dimension()
                 logger.info(f"Model loaded. Embedding dimension: {self._embedding_dimension}")
 
                 # Create vector table now that we know the dimension


### PR DESCRIPTION
## Summary
- Fix deprecated `get_sentence_embedding_dimension()` → `get_embedding_dimension()` for sentence-transformers 5.x compatibility
- Add Known Issues documentation to all .md files
- Add Issue Resolution Workflow to AGENTS.md and DEVELOPMENT.md

## Test plan
- [x] Local test: semantic cache loads model successfully with new API
- [x] `get_embedding_dimension()` returns 384 (correct for all-MiniLM-L6-v2)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #252