### PR TITLE
fix(resolve): handle string profile conversion in URL resolver

### DIFF
--- a/scripts/resolve.py
+++ b/scripts/resolve.py
@@ -220,6 +220,9 @@ def synthesize_results(query: str, results: list[ResolvedResult], api_key: str, 
 def resolve_url(
     url: str, max_chars: int = MAX_CHARS, profile: Profile = Profile.BALANCED
 ) -> dict[str, Any]:
+    # Convert string profile to enum if needed
+    if isinstance(profile, str):
+        profile = Profile(profile.lower())
     for result in resolve_url_stream(url, max_chars, profile):
         if result.get("source") != "partial":
             return result
@@ -229,6 +232,9 @@ def resolve_url(
 def resolve_url_stream(
     url: str, max_chars: int = MAX_CHARS, profile: Profile = Profile.BALANCED
 ) -> Generator[dict[str, Any], None, None]:
+    # Convert string profile to enum if needed
+    if isinstance(profile, str):
+        profile = Profile(profile.lower())
     logger.info(f"Resolving URL: {url}")
 
     # Check semantic cache first


### PR DESCRIPTION
## Summary
- Fix AttributeError when calling `resolve_url()` with string profile (e.g., `'balanced'`)
- Add profile string to enum conversion in both `resolve_url()` and `resolve_url_stream()`

## Test plan
- [x] Local test: `resolve_url('https://react.dev/learn', profile='balanced')` returns content from llms.txt
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)