### PR TITLE
docs: add known issues #259 and #260

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ See [CHANGELOG.md](CHANGELOG.md) for current known issues:
 | [#253](https://github.com/d-oit/do-web-doc-resolver/issues/253) | Rust semantic-cache security alerts (upstream) | Open |
 | [#255](https://github.com/d-oit/do-web-doc-resolver/issues/255) | Dependabot vulnerabilities pending review | Open |
 | [#256](https://github.com/d-oit/do-web-doc-resolver/issues/256) | Release workflow out-of-order merge handling | Open |
+| [#259](https://github.com/d-oit/do-web-doc-resolver/issues/259) | Python URL resolver needs quality threshold fallback | Open |
+| [#260](https://github.com/d-oit/do-web-doc-resolver/issues/260) | Update duckduckgo_search to ddgs package | Open |
 
 ### Semantic Cache Workaround
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Screenshots and visual assets are stored in `assets/screenshots/`. See [assets/R
 | [#253](https://github.com/d-oit/do-web-doc-resolver/issues/253) | Rust semantic-cache feature security alerts | Avoid `semantic-cache` feature; track upstream `chaotic_semantic_memory#88` |
 | [#255](https://github.com/d-oit/do-web-doc-resolver/issues/255) | Dependabot vulnerabilities (1 moderate, 4 low) | Pending review |
 | [#256](https://github.com/d-oit/do-web-doc-resolver/issues/256) | Release workflow squash merge resets versions | Re-apply version bumps after out-of-order merges |
+| [#259](https://github.com/d-oit/do-web-doc-resolver/issues/259) | Python URL resolver rejects content below quality threshold | CLI returns best available; Python needs fallback logic |
+| [#260](https://github.com/d-oit/do-web-doc-resolver/issues/260) | duckduckgo_search package renamed to ddgs | Update import: `from ddgs import DDGS` |
 
 For detailed tracking, see [CHANGELOG.md](CHANGELOG.md).
 


### PR DESCRIPTION
## Summary

Adds two new known issues discovered during provider testing to documentation:
- #259: Python URL resolver needs quality threshold fallback (rejects content < 0.65)
- #260: duckduckgo_search package renamed to ddgs

These issues were identified while testing all providers with both the Python skill and Rust CLI.

## Changes

- Updated AGENTS.md Known Issues table with #259 and #260
- Updated README.md Known Issues table with #259 and #260

## Test plan

- [x] Documentation builds correctly
- [x] Issue links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)