### PR TITLE
Fix Nightly Bridge Integration workflow failures

### DIFF
--- a/.github/workflows/nightly-bridge.yml
+++ b/.github/workflows/nightly-bridge.yml
@@ -26,9 +26,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: '1.85'
+          components: rustfmt
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
This PR addresses the failures in the Nightly Bridge Integration workflow:
1. **Rust Format Error**: The `cargo fmt` step was failing because the `rustfmt` component was not explicitly included in the toolchain setup. I added `components: rustfmt` to the `dtolnay/rust-toolchain` step.
2. **Node.js 20 Deprecation Warning**: Updated `actions/cache@v4` to `actions/cache@v5` which runs on Node.js 24.

I also verified that other actions used in the workflow (`actions/checkout@v6` and `actions/setup-python@v6`) are already compatible with Node.js 24. All quality gate checks and tests passed locally.

Fixes #275

---
*PR created automatically by Jules for task [9469740493238192727](https://jules.google.com/task/9469740493238192727) started by @d-oit*