### PR TITLE
Improve LaTeX and Code Block Preservation in Rust CLI Output

### DIFF
--- a/cli/src/compaction.rs
+++ b/cli/src/compaction.rs
@@ -54,7 +54,20 @@ fn is_boilerplate(line: &str) -> bool {
     }
 
     // Protect Markdown structural elements and LaTeX markers from being treated as boilerplate
-    let protected_markers = ["```", "$$", "---", "###", "---", "|", ">"];
+    let protected_markers = [
+        "```",
+        "$$",
+        "---",
+        "###",
+        "|",
+        ">",
+        "{\\displaystyle",
+        "\\textstyle",
+        "\\begin{aligned}",
+        "\\end{aligned}",
+        "<pre",
+        "<code",
+    ];
     if protected_markers.iter().any(|&m| line.contains(m)) {
         return false;
     }


### PR DESCRIPTION
This change improves the Markdown output of the WDR CLI when processing complex, JavaScript-heavy, or math-heavy sites.

Key changes:
- Updated the content compaction logic in `cli/src/compaction.rs` to protect specific markers from being treated as boilerplate.
- Added protection for LaTeX environments: `{\displaystyle`, `\textstyle`, `\begin{aligned}`, and `\end{aligned}`.
- Added protection for HTML code tags: `<pre>` and `<code>`.
- Removed a duplicate `---` entry in the `protected_markers` list.

These improvements ensure that "LLM-ready" Markdown output preserves critical technical and mathematical information, meeting the project's quality standards for documentation synthesis. Verified the fixes against Wikipedia (Quadratic Formula) and React.dev documentation.

---
*PR created automatically by Jules for task [17760103295668045103](https://jules.google.com/task/17760103295668045103) started by @d-oit*