### PR TITLE
docs: align AGENTS.md with upstream template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,80 @@
 # AGENTS.md
 
-> **do-web-doc-resolver** — resolves queries or URLs into clean Markdown via a provider cascade.
+> **do-web-doc-resolver** — resolves queries or URLs into clean Markdown via a
+> provider cascade.
+> Supported by: Claude Code, Windsurf, Gemini CLI, Codex, Copilot, OpenCode,
+> Devin, Amp, Zed, Warp, RooCode, Jules
 > See [agents.md](https://agents.md) for spec.
 
-## Coding Workflow
+## Named Constants
 
-- **Branch naming**: `feat/`, `fix/`, `chore/`, `docs/`
-- **Commit format**: Conventional Commits (`type(scope): description`)
-- **File size limit**: 500 lines max per source file
-- **Quality gate command**: `./scripts/quality_gate.sh`
-- **Pre-commit hooks**: `pre-commit run --all-files` (requires `pip install pre-commit`)
-- **Secret scanning**: Gitleaks (`.gitleaks.toml`)
-- **Test commands**:
-  - Python: `pytest -m "not live"`
-  - Rust: `cd cli && cargo test`
-  - Web: `cd web && npx playwright test --project=desktop`
-- **Local CI**: `act` (requires Docker, see `.actrc`)
+```bash
+# File size limits (lines)
+readonly MAX_LINES_PER_SOURCE_FILE=500
+readonly MAX_LINES_PER_SKILL_MD=250
+readonly MAX_LINES_AGENTS_MD=150
+
+# Retry and polling configuration
+readonly DEFAULT_MAX_RETRIES=3
+readonly DEFAULT_RETRY_DELAY_SECONDS=5
+readonly DEFAULT_POLL_INTERVAL_SECONDS=5
+readonly DEFAULT_MAX_POLL_ATTEMPTS=12
+readonly DEFAULT_TIMEOUT_SECONDS=1800
+
+# Git/PR configuration
+readonly MAX_COMMIT_SUBJECT_LENGTH=72
+readonly MAX_PR_TITLE_LENGTH=72
+```
+
+## Setup
+
+```bash
+# Install git pre-commit hooks
+./scripts/setup-hooks.sh
+```
+
+## Version Management
+
+This repository uses `pyproject.toml`, `cli/Cargo.toml`, and `web/package.json`
+for versioning.
+Run `./scripts/sync_versions.py` to ensure all versions are in sync.
+
+## Quality Gate (Required Before Commit)
+
+```bash
+./scripts/quality_gate.sh # Always run before committing. Fix all errors.
+```
+
+### Test Commands
+
+- Python: `pytest -m "not live"`
+- Rust: `cd cli && cargo test`
+- Web: `cd web && npx playwright test --project=desktop`
+
+**Guard Rails:**
+
+- **Temporary Files**: NEVER create temporary files or debug outputs in the
+  repository root or source directories. Always use system temporary
+  directories (e.g., `/tmp` or via `mktemp`).
+- **Secret Scanning**: Gitleaks (`.gitleaks.toml`) is enforced via CI and
+  pre-commit hooks to prevent credential leakage.
+- **Git Config**: Pre-commit validates git config. If global hooks detected,
+  run `git config --global --unset core.hooksPath` or use
+  `SKIP_GLOBAL_HOOKS_CHECK=true`.
+
+## Code Style
+
+- Max `${MAX_LINES_PER_SOURCE_FILE}` lines/file;
+  `${MAX_LINES_PER_SKILL_MD}`/`SKILL.md`; `${MAX_LINES_AGENTS_MD}`/`AGENTS.md`
+- `SKILL.md` must start with frontmatter; No magic numbers - use named constants
+- **Reference format**: `` `references/filename.md` - Description ``
+- Shell: `shellcheck` (severity=error); Markdown: `markdownlint`;
+  Diagrams: `mermaid`
 - **Web dependencies**: Use `npm ci --legacy-peer-deps` (ESLint 10 peer conflict)
-- **PR Checklist**:
-  - `scripts/quality_gate.sh` passes
-  - Linting clean (ruff/black, cargo fmt/clippy, npm run lint)
-  - Markdown linting passes (`markdownlint`)
-  - No new secrets committed (Gitleaks)
-  - `AGENTS.md` updated if repository structure changed
 
 ## Repository Structure
 
-```
+```text
 ./
 ├── scripts/               # Core Python logic
 ├── cli/                   # Rust CLI (do-wdr)
@@ -41,19 +89,46 @@
 └── assets/                # Visual assets
 ```
 
-### Configuration Files (from github-template-ai-agents)
+### Configuration Files
+
+- `.actrc` - Local CI testing with `act`
 - `.gitleaks.toml` - Secret scanning configuration
-- `.pre-commit-config.yaml` - Pre-commit hooks (Gitleaks, shellcheck, markdownlint)
+- `.pre-commit-config.yaml` - Pre-commit hooks configuration
 - `commitlint.config.cjs` - Commit message linting
 - `markdownlint.toml` - Markdown linting rules
-- `.actrc` - Local CI testing with `act`
+
+## PR & Commit Instructions
+
+- **Branch naming**: `feat/`, `fix/`, `chore/`, `docs/`
+- **Commit format**: Conventional Commits (`type(scope): description`)
+  (max `${MAX_PR_TITLE_LENGTH}` chars)
+- Branch per feature; One concern per PR; Never commit to `main`
+
+### Commit Type Mapping
+
+| Intent | Type | Scope suggestion |
+| --- | --- | --- |
+| Security patch / hardening | `fix` | `security` |
+| New security feature/control | `feat` | `security` |
+| Security-related CI/tooling | `ci` | `security` |
+
+**Allowed types**: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+`refactor`, `revert`, `style`, `test`
+
+### PR Checklist
+
+- `scripts/quality_gate.sh` passes
+- Linting clean (`ruff`, `black`, `cargo fmt`, `cargo clippy`, `npm run lint`)
+- Markdown linting passes (`markdownlint`)
+- No new secrets committed (Gitleaks)
+- `AGENTS.md` updated if repository structure or skills change
 
 ## Project Documentation
 
 Detailed domain knowledge is located in `agents-docs/`.
 
 | Topic | File |
-|---|---|
+| --- | --- |
 | Development | [agents-docs/DEVELOPMENT.md](agents-docs/DEVELOPMENT.md) |
 | Configuration | [agents-docs/CONFIG.md](agents-docs/CONFIG.md) |
 | Deployment | [agents-docs/DEPLOYMENT.md](agents-docs/DEPLOYMENT.md) |
@@ -67,7 +142,7 @@ Detailed domain knowledge is located in `agents-docs/`.
 ## Skills
 
 | Skill | Path |
-|---|---|
+| --- | --- |
 | do-web-doc-resolver | .agents/skills/do-web-doc-resolver/ |
 | do-wdr-cli | .agents/skills/do-wdr-cli/ |
 | do-wdr-assets | .agents/skills/do-wdr-assets/ |
@@ -81,3 +156,22 @@ Detailed domain knowledge is located in `agents-docs/`.
 | readme-best-practices | .agents/skills/readme-best-practices/ |
 | anti-ai-slop | .agents/skills/anti-ai-slop/ |
 | vercel-cli | .agents/skills/vercel-cli/ |
+
+## Security
+
+- **Secret Scanning**: Gitleaks is enforced via CI and pre-commit to prevent
+  credential leakage.
+- No secrets in commits (use `.env`); Pin Actions to SHA (with `# vX.Y` comment)
+- No untrusted MCPs; Report vulnerabilities via Private Advisories
+
+## Agent Guidance
+
+- **Plan**: Produce written plan, wait for confirmation for non-trivial tasks.
+- **Policies**: See `agents-docs/WORKFLOW.md` for Atomic Commit & Pre-Existing
+  Issue resolution.
+- **Learning**: After work, run `learn` or append discoveries to nearest
+  `AGENTS.md`.
+- **Context**: Delegate to sub-agents; Use `/clear`; Load skills only when
+  needed.
+
+See `agents-docs/` for detailed reference documentation.


### PR DESCRIPTION
Align local AGENTS.md with d-o-hub/github-template-ai-agents standard. Added missing sections (Named Constants, Setup, Version Management, Commit Type Mapping, Security, Agent Guidance) while preserving and refining local-specific content (Repository Structure, Skills, PR Checklist, specific test commands). Verified with markdownlint and quality gate.

Fixes #316

---
*PR created automatically by Jules for task [127835943968227264](https://jules.google.com/task/127835943968227264) started by @d-oit*