### PR TITLE
Add docs index and clarify AGENTS vs agents-docs roles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # AGENTS.md
 
+> **Primary Integration Guide** — This file is the main entry point for AI
+> agents and developers integrating the resolver as a skill. For deep
+> technical reference, see **[agents-docs/](agents-docs/README.md)**.
+
 > **do-web-doc-resolver** — resolves queries or URLs into clean Markdown via a
 > provider cascade.
 > Supported by: Claude Code, Windsurf, Gemini CLI, Codex, Copilot, OpenCode,
@@ -125,10 +129,11 @@ Run `./scripts/sync_versions.py` to ensure all versions are in sync.
 
 ## Project Documentation
 
-Detailed domain knowledge is located in `agents-docs/`.
+Detailed technical reference material is located in `agents-docs/`.
 
 | Topic | File |
 | --- | --- |
+| Reference Index | [agents-docs/README.md](agents-docs/README.md) |
 | Development | [agents-docs/DEVELOPMENT.md](agents-docs/DEVELOPMENT.md) |
 | Configuration | [agents-docs/CONFIG.md](agents-docs/CONFIG.md) |
 | Deployment | [agents-docs/DEPLOYMENT.md](agents-docs/DEPLOYMENT.md) |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Resolve queries or URLs into compact, LLM-ready markdown using an intelligent, low-cost cascade**
 
+Full documentation → **[docs/index.md](docs/index.md)**
+
 ## Overview
 
 This project implements a v4 cascade resolver with Python core, Rust CLI, and web UI that prioritizes free and low-cost data sources:

--- a/agents-docs/README.md
+++ b/agents-docs/README.md
@@ -1,0 +1,20 @@
+# Reference Documentation (`agents-docs/`)
+
+This directory contains deep reference material and internal details for the **do-web-doc-resolver** project.
+
+For a high-level guide on integrating the resolver as an agent skill, please refer to **[AGENTS.md](../AGENTS.md)**.
+
+## Contents
+
+- **[OVERVIEW.md](OVERVIEW.md)**: Technical architecture and component breakdown.
+- **[CONFIG.md](CONFIG.md)**: Comprehensive reference for environment variables and configuration files.
+- **[DEVELOPMENT.md](DEVELOPMENT.md)**: Local setup, quality gate instructions, and maintenance tasks.
+- **[DEPLOYMENT.md](DEPLOYMENT.md)**: Deployment strategies and CI/CD pipelines.
+- **[RELEASES.md](RELEASES.md)**: Versioning policy and release procedures.
+- **[SEMANTIC_HEALTH.md](SEMANTIC_HEALTH.md)**: Metrics and standards for LLM-ready output quality.
+- **[ASSETS.md](ASSETS.md)**: Management of screenshots and visual documentation.
+- **[ISSUES.md](ISSUES.md)**: Known issues and technical debt tracking.
+
+## Purpose
+
+While `AGENTS.md` provides the "how-to" for agent authors, this directory provides the "why" and the technical specifications for contributors and maintainers. It covers provider routing behavior, cache semantics, output schemas, and internal orchestration logic.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+# Documentation Overview
+
+Welcome to the **do-web-doc-resolver** documentation. This project provides a powerful, cost-efficient cascade resolver for turning queries and URLs into LLM-ready Markdown.
+
+## 🚀 Getting Started
+
+If you are new to the project, start with the **[README.md](../README.md)** for a quick overview, installation instructions, and basic usage examples.
+
+## 🧠 Architecture & Internals
+
+For a deeper dive into how the resolver works under the hood:
+- **[Project Overview](../agents-docs/OVERVIEW.md)**: High-level architectural overview and component breakdown.
+- **[Cascade Decision Trees](../.agents/skills/do-web-doc-resolver/references/CASCADE.md)**: Detailed logic for query and URL resolution.
+- **[Provider Details](../.agents/skills/do-web-doc-resolver/references/PROVIDERS.md)**: Information about the various search and extraction providers.
+- **[Semantic Health](../agents-docs/SEMANTIC_HEALTH.md)**: Monitoring and maintaining the quality of semantic outputs.
+
+## 🤖 Agent Integration
+
+The resolver is designed to be used as a skill by AI agents.
+- **[AGENTS.md](../AGENTS.md)**: **Primary Guide** for integrating the resolver as an agent skill, including named constants and PR instructions.
+- **[Skill Definitions](../.agents/skills/)**: Canonical skill definitions for various agent platforms.
+- **[Deep Reference (agents-docs/)](../agents-docs/README.md)**: Detailed reference material for provider routing, cache semantics, and output schemas.
+
+## 💻 CLI Usage
+
+The project includes a robust Rust-based CLI.
+- **[CLI Reference](../.agents/skills/do-web-doc-resolver/references/CLI.md)**: General CLI usage patterns.
+- **[Rust CLI Architecture](../.agents/skills/do-web-doc-resolver/references/RUST_CLI.md)**: Internal design of the `do-wdr` binary.
+
+## 🌐 Web UI & Deployment
+
+- **[Web UI Details](../agents-docs/OVERVIEW.md#3-web-ui-web)**: Overview of the Next.js web interface.
+- **[Deployment Guide](../agents-docs/DEPLOYMENT.md)**: Instructions for deploying the resolver and its web UI.
+- **[Configuration](../agents-docs/CONFIG.md)**: Full reference for environment variables and configuration files.
+
+## 🛠 Development & Contributing
+
+- **[Development Guide](../agents-docs/DEVELOPMENT.md)**: Setup for local development and quality gate processes.
+- **[Testing Documentation](../.agents/skills/do-web-doc-resolver/references/TESTING.md)**: Overview of the test suite (Python, Rust, and E2E).
+- **[Standards](standards.md)**: 2026 LLM-readable documentation standards.
+- **[Releases](../agents-docs/RELEASES.md)**: Versioning and release process.


### PR DESCRIPTION
This PR improves the documentation structure by establishing a clear hierarchy and entry points:

1. **Central Index**: Added `docs/index.md` to serve as the "docs home", linking to all major documentation areas (getting started, architecture, agent integration, CLI, web UI, and development).
2. **Role Clarification**: 
   - Explicitly labeled `AGENTS.md` as the **Primary Integration Guide** for agent authors.
   - Added `agents-docs/README.md` to clarify that the directory contains **Deep Reference** material.
3. **Improved Discoverability**:
   - Linked the central index from the `README.md`.
   - Cross-linked `AGENTS.md` and `agents-docs/` to facilitate jumping between high-level guides and detailed references.

These changes reduce confusion for new contributors and agent authors about where to start and how to navigate the technical documentation.

Fixes #323

---
*PR created automatically by Jules for task [3198411811440388816](https://jules.google.com/task/3198411811440388816) started by @d-oit*