### PR TITLE
Implement startup pre-warm for top-N frequently accessed domains

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -90,6 +90,9 @@ pub struct CacheConfig {
     /// Synthesis cache configuration
     #[serde(default)]
     pub synthesis: SynthesisCacheConfig,
+    /// Cache pre-warming configuration
+    #[serde(default)]
+    pub prewarm: PrewarmConfig,
 }
 
 /// Synthesis cache configuration
@@ -116,6 +119,50 @@ impl Default for SynthesisCacheConfig {
         Self {
             enabled: default_synthesis_cache_enabled(),
             ttl: default_synthesis_cache_ttl(),
+        }
+    }
+}
+
+/// Cache pre-warming configuration
+#[derive(Debug, Clone, Deserialize)]
+pub struct PrewarmConfig {
+    /// Enable cache pre-warming
+    #[serde(default = "default_prewarm_enabled")]
+    pub enabled: bool,
+    /// Number of top domains to pre-warm
+    #[serde(default = "default_prewarm_top_n")]
+    pub top_n_domains: usize,
+    /// Profile to use for pre-warming
+    #[serde(default = "default_prewarm_profile")]
+    pub profile: Profile,
+    /// Maximum concurrency for pre-warming
+    #[serde(default = "default_prewarm_max_concurrency")]
+    pub max_concurrency: usize,
+}
+
+fn default_prewarm_enabled() -> bool {
+    true
+}
+
+fn default_prewarm_top_n() -> usize {
+    20
+}
+
+fn default_prewarm_profile() -> Profile {
+    Profile::Balanced
+}
+
+fn default_prewarm_max_concurrency() -> usize {
+    4
+}
+
+impl Default for PrewarmConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_prewarm_enabled(),
+            top_n_domains: default_prewarm_top_n(),
+            profile: default_prewarm_profile(),
+            max_concurrency: default_prewarm_max_concurrency(),
         }
     }
 }
@@ -288,6 +335,18 @@ impl Config {
         if other.cache.synthesis.ttl != default_synthesis_cache_ttl() {
             self.cache.synthesis.ttl = other.cache.synthesis.ttl;
         }
+        if other.cache.prewarm.enabled != default_prewarm_enabled() {
+            self.cache.prewarm.enabled = other.cache.prewarm.enabled;
+        }
+        if other.cache.prewarm.top_n_domains != default_prewarm_top_n() {
+            self.cache.prewarm.top_n_domains = other.cache.prewarm.top_n_domains;
+        }
+        if other.cache.prewarm.profile != default_prewarm_profile() {
+            self.cache.prewarm.profile = other.cache.prewarm.profile;
+        }
+        if other.cache.prewarm.max_concurrency != default_prewarm_max_concurrency() {
+            self.cache.prewarm.max_concurrency = other.cache.prewarm.max_concurrency;
+        }
         if other.profile != Profile::Balanced {
             self.profile = other.profile;
         }
@@ -414,6 +473,22 @@ impl Config {
         }
         if let Ok(val) = env::var("DO_WDR_SYNTHESIS_CACHE__TTL") {
             config.cache.synthesis.ttl = val.parse().unwrap_or(43200);
+        }
+
+        // Pre-warm config from env vars
+        if let Ok(val) = env::var("DO_WDR_CACHE_PREWARM__ENABLED") {
+            config.cache.prewarm.enabled = val.parse().unwrap_or(true);
+        }
+        if let Ok(val) = env::var("DO_WDR_CACHE_PREWARM__TOP_N") {
+            config.cache.prewarm.top_n_domains = val.parse().unwrap_or(20);
+        }
+        if let Ok(val) = env::var("DO_WDR_CACHE_PREWARM__PROFILE") {
+            if let Ok(p) = val.parse() {
+                config.cache.prewarm.profile = p;
+            }
+        }
+        if let Ok(val) = env::var("DO_WDR_CACHE_PREWARM__MAX_CONCURRENCY") {
+            config.cache.prewarm.max_concurrency = val.parse().unwrap_or(4);
         }
 
         config

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -19,6 +19,7 @@ pub mod resolver;
 pub mod routing;
 pub mod routing_memory;
 pub mod semantic_cache;
+pub mod startup;
 pub mod synthesis;
 pub mod types;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 use std::process::ExitCode;
+use std::sync::Arc;
 use tracing_subscriber::{EnvFilter, fmt};
 
 use do_wdr_lib::{

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -122,7 +122,14 @@ async fn handle_resolve(
     if skip_cache {
         config.semantic_cache.enabled = false;
     }
-    let resolver = Resolver::with_config(config).await;
+    let resolver = Arc::new(Resolver::with_config(config.clone()).await);
+
+    // Run cache pre-warm
+    let prewarm_resolver = resolver.clone();
+    let prewarm_config = config.clone();
+    tokio::spawn(async move {
+        do_wdr_lib::startup::prewarm_cache(prewarm_resolver, prewarm_config).await;
+    });
 
     let result = if synthesize {
         resolver.resolve_aggregated(input).await

--- a/cli/src/resolver/mod.rs
+++ b/cli/src/resolver/mod.rs
@@ -292,6 +292,16 @@ impl Resolver {
 
         Err(ResolverError::Provider("No provider succeeded".to_string()))
     }
+
+    /// Access to routing memory
+    pub fn routing_memory(&self) -> Arc<Mutex<RoutingMemory>> {
+        self.routing_memory.clone()
+    }
+
+    /// Access to semantic cache
+    pub fn cache(&self) -> Option<&SemanticCache> {
+        self.cache.as_ref()
+    }
 }
 
 // Note: Default trait removed because Resolver::new() is now async

--- a/cli/src/resolver/mod.rs
+++ b/cli/src/resolver/mod.rs
@@ -86,16 +86,25 @@ impl Resolver {
 
     /// Resolve a URL using the URL cascade
     pub async fn resolve_url(&self, url: &str) -> Result<ResolvedResult, ResolverError> {
+        self.resolve_url_with_config(url, &self.config).await
+    }
+
+    /// Resolve a URL using the URL cascade with custom config
+    pub async fn resolve_url_with_config(
+        &self,
+        url: &str,
+        config: &Config,
+    ) -> Result<ResolvedResult, ResolverError> {
         self.url_cascade
             .resolve(
                 url,
                 self.cache.as_ref(),
-                &self.config,
+                config,
                 self.negative_cache.clone(),
                 self.circuit_breakers.clone(),
                 self.routing_memory.clone(),
-                self.config.max_chars,
-                self.config.min_chars,
+                config.max_chars,
+                config.min_chars,
             )
             .await
     }

--- a/cli/src/routing_memory.rs
+++ b/cli/src/routing_memory.rs
@@ -86,10 +86,7 @@ impl RoutingMemory {
             .domain_stats
             .iter()
             .map(|(domain, stats)| {
-                let total_attempts: usize = stats
-                    .values()
-                    .map(|s| s.success + s.failure)
-                    .sum();
+                let total_attempts: usize = stats.values().map(|s| s.success + s.failure).sum();
                 (domain.clone(), total_attempts)
             })
             .collect();

--- a/cli/src/routing_memory.rs
+++ b/cli/src/routing_memory.rs
@@ -79,6 +79,30 @@ impl RoutingMemory {
 
         ranked
     }
+
+    /// Get the top N most frequently accessed domains
+    pub fn top_domains(&self, n: usize) -> Vec<String> {
+        let mut domain_counts: Vec<(String, usize)> = self
+            .domain_stats
+            .iter()
+            .map(|(domain, stats)| {
+                let total_attempts: usize = stats
+                    .values()
+                    .map(|s| s.success + s.failure)
+                    .sum();
+                (domain.clone(), total_attempts)
+            })
+            .collect();
+
+        // Sort by attempt count descending
+        domain_counts.sort_by(|a, b| b.1.cmp(&a.1));
+
+        domain_counts
+            .into_iter()
+            .take(n)
+            .map(|(domain, _)| domain)
+            .collect()
+    }
 }
 
 fn extract_domain(target: &str) -> Option<String> {

--- a/cli/src/semantic_cache.rs
+++ b/cli/src/semantic_cache.rs
@@ -348,6 +348,40 @@ impl SemanticCache {
         Ok(None)
     }
 
+    /// Check if a valid entry exists for the given query
+    #[cfg(feature = "semantic-cache")]
+    pub async fn has_valid_entry(&self, query: &str) -> bool {
+        // Normalize query for consistent lookup
+        let normalized: String = query
+            .to_lowercase()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        // First attempt exact match lookup via concept ID
+        if let Ok(Some(_)) = self.framework.get_concept(&normalized).await {
+            return true;
+        }
+
+        // Generate query vector
+        let query_vector = self.encode_query(query);
+
+        // Probe semantic memory
+        if let Ok(hits) = self.framework.probe(query_vector, 1).await {
+            if let Some((_, score)) = hits.first() {
+                return *score >= self.config.threshold;
+            }
+        }
+
+        false
+    }
+
+    /// Check if a valid entry exists (no-op without feature)
+    #[cfg(not(feature = "semantic-cache"))]
+    pub async fn has_valid_entry(&self, _query: &str) -> bool {
+        false
+    }
+
     /// Get a cached synthesis result by key
     #[cfg(feature = "semantic-cache")]
     pub async fn get_synthesis(&self, key: &str) -> StdResult<Option<String>, ResolverError> {

--- a/cli/src/startup.rs
+++ b/cli/src/startup.rs
@@ -58,10 +58,10 @@ pub async fn prewarm_cache(resolver: Arc<Resolver>, config: Config) {
                 tracing::debug!("Pre-warming: {} with profile {:?}", url, config_clone.cache.prewarm.profile);
                 // Use a temporary config with the pre-warm profile
                 let mut prewarm_config = config_clone.clone();
-                prewarm_config.profile = config_clone.cache.prewarm.profile.clone();
+                prewarm_config.profile = config_clone.cache.prewarm.profile;
 
-                // We use resolve_url which exists on Resolver
-                let _ = resolver_clone.resolve_url(&url).await;
+                // We use resolve_url_with_config which exists on Resolver
+                let _ = resolver_clone.resolve_url_with_config(&url, &prewarm_config).await;
             } else {
                 tracing::debug!("Skip pre-warm (already cached): {}", url);
             }

--- a/cli/src/startup.rs
+++ b/cli/src/startup.rs
@@ -55,13 +55,19 @@ pub async fn prewarm_cache(resolver: Arc<Resolver>, config: Config) {
             };
 
             if !already_cached {
-                tracing::debug!("Pre-warming: {} with profile {:?}", url, config_clone.cache.prewarm.profile);
+                tracing::debug!(
+                    "Pre-warming: {} with profile {:?}",
+                    url,
+                    config_clone.cache.prewarm.profile
+                );
                 // Use a temporary config with the pre-warm profile
                 let mut prewarm_config = config_clone.clone();
                 prewarm_config.profile = config_clone.cache.prewarm.profile;
 
                 // We use resolve_url_with_config which exists on Resolver
-                let _ = resolver_clone.resolve_url_with_config(&url, &prewarm_config).await;
+                let _ = resolver_clone
+                    .resolve_url_with_config(&url, &prewarm_config)
+                    .await;
             } else {
                 tracing::debug!("Skip pre-warm (already cached): {}", url);
             }

--- a/cli/src/startup.rs
+++ b/cli/src/startup.rs
@@ -1,0 +1,73 @@
+//! Startup and pre-warming logic for the Web Documentation Resolver CLI.
+
+use crate::config::Config;
+use crate::resolver::Resolver;
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+
+/// Pre-warm the semantic cache with top-N frequently accessed domains.
+pub async fn prewarm_cache(resolver: Arc<Resolver>, config: Config) {
+    if !config.cache.prewarm.enabled {
+        return;
+    }
+
+    let top_domains = {
+        let rm = resolver.routing_memory();
+        let memory = rm.lock().unwrap();
+        memory.top_domains(config.cache.prewarm.top_n_domains)
+    };
+
+    if top_domains.is_empty() {
+        tracing::debug!("No domains found in routing memory for pre-warming");
+        return;
+    }
+
+    if resolver.cache().is_none() {
+        tracing::debug!("Semantic cache disabled, skipping pre-warm");
+        return;
+    }
+
+    tracing::info!("Starting cache pre-warm for {} domains", top_domains.len());
+
+    let semaphore = Arc::new(Semaphore::new(config.cache.prewarm.max_concurrency));
+    let mut tasks = Vec::new();
+
+    for domain in top_domains {
+        let sem = semaphore.clone();
+        let resolver_clone = resolver.clone();
+        let config_clone = config.clone();
+        let domain_str = domain.clone();
+
+        // Ensure we are pre-warming with a full URL if it's a domain
+        let url = if !domain_str.starts_with("http") {
+            format!("https://{}", domain_str)
+        } else {
+            domain_str.clone()
+        };
+
+        tasks.push(tokio::spawn(async move {
+            let _permit = sem.acquire().await.unwrap();
+
+            let already_cached = if let Some(cache) = resolver_clone.cache() {
+                cache.has_valid_entry(&url).await
+            } else {
+                false
+            };
+
+            if !already_cached {
+                tracing::debug!("Pre-warming: {} with profile {:?}", url, config_clone.cache.prewarm.profile);
+                // Use a temporary config with the pre-warm profile
+                let mut prewarm_config = config_clone.clone();
+                prewarm_config.profile = config_clone.cache.prewarm.profile.clone();
+
+                // We use resolve_url which exists on Resolver
+                let _ = resolver_clone.resolve_url(&url).await;
+            } else {
+                tracing::debug!("Skip pre-warm (already cached): {}", url);
+            }
+        }));
+    }
+
+    futures::future::join_all(tasks).await;
+    tracing::info!("Cache pre-warm complete");
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -8,6 +8,7 @@ import { parseProviderResults, extractNormalizedUrls, type ProviderResult } from
 import { PROVIDERS, PROFILES, ProfileId, UiProvider, toApiProviderId } from "@/app/constants";
 import Sidebar from "@/app/components/Sidebar";
 import MainContent from "@/app/components/MainContent";
+import { getTopDomains } from "@/lib/records";
 
 export default function Home() {
   const [query, setQuery] = useState("");
@@ -41,6 +42,35 @@ export default function Home() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const keySource = useMemo(() => resolveKeySource(apiKeys, serverKeyStatus), [apiKeys, serverKeyStatus]);
+
+  const prewarmCache = useCallback(async () => {
+    const topDomains = await getTopDomains(20);
+    if (topDomains.length === 0) return;
+
+    console.log(`[Cache] Pre-warming ${topDomains.length} domains...`);
+
+    // Process in batches of 4 for concurrency control
+    const batchSize = 4;
+    for (let i = 0; i < topDomains.length; i += batchSize) {
+      const batch = topDomains.slice(i, i + batchSize);
+      await Promise.allSettled(
+        batch.map((domain) => {
+          const url = domain.startsWith("http") ? domain : `https://${domain}`;
+          return fetch("/api/resolve", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              query: url,
+              ...apiKeys,
+              profile: "balanced",
+              maxChars: 4000, // Reduced for pre-warm efficiency
+            }),
+          });
+        })
+      );
+    }
+    console.log("[Cache] Pre-warm complete");
+  }, [apiKeys]);
 
   const SEARCH_STORAGE_KEY = "wdr-search-state";
 
@@ -127,8 +157,11 @@ export default function Home() {
         // Fallback: just use defaults
         setLoaded(true);
         inputRef.current?.focus();
+
+        // Trigger cache pre-warm
+        prewarmCache();
       });
-  }, []);
+  }, [prewarmCache]);
 
   // Persist UI state changes (skip before first load)
   useEffect(() => {

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -159,7 +159,7 @@ export default function Home() {
         inputRef.current?.focus();
 
         // Trigger cache pre-warm
-        prewarmCache();
+        void prewarmCache();
       });
   }, [prewarmCache]);
 

--- a/web/lib/records.ts
+++ b/web/lib/records.ts
@@ -183,3 +183,28 @@ export function getAnalytics(): {
     ttlDays: config.ttlMs / (24 * 60 * 60 * 1000),
   };
 }
+
+/**
+ * Get top N domains based on record frequency
+ */
+export async function getTopDomains(n: number): Promise<string[]> {
+  cleanupExpired();
+  const domains = new Map<string, number>();
+
+  for (const record of store.values()) {
+    if (record.url) {
+      try {
+        const url = new URL(record.url);
+        const domain = url.hostname.toLowerCase();
+        domains.set(domain, (domains.get(domain) || 0) + 1);
+      } catch {
+        // Ignore invalid URLs
+      }
+    }
+  }
+
+  return Array.from(domains.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([domain]) => domain);
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Implemented cache pre-warming for top-N frequently accessed domains in both the Rust CLI and Next.js app. This feature reduces cold-start latency by resolving and caching content for common domains during application startup. The implementation uses safe concurrency patterns (Arc/tokio::spawn in Rust, batching in JS) and ensures pre-warming is non-blocking for the primary user flow.

Fixes #333

---
*PR created automatically by Jules for task [17833016712333481427](https://jules.google.com/task/17833016712333481427) started by @d-oit*