### PR TITLE
fix(nightly): replace direct push to main with PR creation

### DIFF
--- a/.github/workflows/nightly-bridge.yml
+++ b/.github/workflows/nightly-bridge.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   nightly-build-and-test:
@@ -71,14 +72,24 @@ jobs:
       - name: Format Rust
         run: cd cli && cargo fmt
 
-      - name: Commit and Push changes
+      - name: Commit and create PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           if ! git diff --cached --quiet; then
+            BRANCH="chore/nightly-format-$(date +%Y%m%d)"
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout -b "$BRANCH"
             git commit -m "chore(nightly): automated format and fixup"
-            git push
+            git push origin "$BRANCH"
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(nightly): automated format and fixup" \
+              --body "Auto-format fixup from nightly CI run $(date +%Y-%m-%d)." \
+              --label automated
           else
             echo "No changes to commit"
           fi

--- a/.opencode/plans/012-correctness-and-safety-fixes.md
+++ b/.opencode/plans/012-correctness-and-safety-fixes.md
@@ -1,0 +1,100 @@
+# ADR-012: Correctness & Safety Fixes
+
+**Date:** 2026-05-12
+**Status:** Proposed
+**Context:** Deep audit of Python (`scripts/`), Rust (`cli/src/`), and Web (`web/`) runtimes uncovered 15 critical bugs, security gaps, and misleading implementations that risk data corruption, silent failures, or security exploits.
+
+---
+
+## Goal
+
+Fix all critical bugs, security vulnerabilities, and misleading code paths so that every provider can be reached, every shared state is thread-safe, and no production path silently fails or bypasses security checks.
+
+---
+
+## GOAP Waves
+
+### Wave 1: Thread Safety & Shared State (Day 1)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| T1 | `scripts/circuit_breaker.py` | Add `threading.Lock` to `CircuitBreakerRegistry.register()` and `is_open()`. Wrap `breakers` dict access. Fix falsy-threshold bug: `threshold if threshold is not None else self.default_threshold` | HIGH |
+| T2 | `scripts/routing_memory.py` | Add `threading.Lock` to `RoutingMemory.record()` and `rank_providers()`. Wrap `domain_stats` access. Extract scoring magic numbers (`0.5`, `7.0`, `1000.0`) to `SCORE_BASE`, `RECENCY_DECAY_DAYS`, `SCORE_SCALE` | HIGH |
+| T3 | `scripts/providers_impl.py` | Add `threading.Lock` around `_rate_limits`. Move `MAX_CHARS`, `MIN_CHARS`, `DEFAULT_TIMEOUT` to single source `scripts/constants.py` | HIGH |
+| T4 | `scripts/utils.py` | Add `threading.Lock` around `_global_session` and `_cache`. Move shared constants to `scripts/constants.py` | HIGH |
+| T5 | `scripts/semantic_cache.py` | Add `threading.Lock` to singleton creation. Make `_maybe_evict()` atomic: batch DELETE in a single transaction | HIGH |
+| T6 | `scripts/resolve.py` | Remove monkey-patching (lines 84-87). Create shared instances in `scripts/state.py`, import from both `_url_resolve.py` and `_query_resolve.py` | HIGH |
+
+### Wave 2: Provider Reachability & Resolve Bugs (Day 2)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| P1 | `scripts/resolve.py:176-190` | Add `ProviderType.LLMS_TXT`, `SERPER`, `DOCLING`, `OCR` to `resolve_direct()` dispatch dict | HIGH |
+| P2 | `scripts/models.py:41-49` | Add `else: return 4` to `Profile.max_hops()` default | MEDIUM |
+| P3 | `scripts/providers_impl.py` | Replace all `except Exception: return None` with `except Exception as e: _log.warning(...)` | HIGH |
+| P4 | `scripts/synthesis.py:165-179` | Replace `requests.post` with `get_session().post()`. Extract `MISTRAL_API_URL`, `MISTRAL_MODEL`, `SYNTHESIS_TIMEOUT` constants | MEDIUM |
+| P5 | `scripts/routing.py:158` | Fix `preflight_route` loose pattern matching with exact hostname comparison | MEDIUM |
+| P6 | `scripts/cache_negative.py:11-16` | Remove unused `NegativeCacheEntry` dataclass or wire it into actual usage | LOW |
+| P7 | `scripts/utils.py:36` | Remove dead `TIERED_TTL["exa_mcp"]` entry; add comment explaining key normalization | LOW |
+
+### Wave 3: SSRF & Security Hardening (Day 3)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| S1 | `scripts/providers_impl.py:259-313` | Add `is_safe_url(url)` check before Mistral browser agent call | HIGH |
+| S2 | `scripts/utils.py:229-236` | Make `is_url()` reject `ftp://` and `ftps://` schemes | HIGH |
+| S3 | `web/lib/resolvers/url.ts:7-50` | Add `validateUrlForFetchAsync(url)` at top of `safeFetch()` | MEDIUM |
+| S4 | `scripts/utils.py:82-91` | Change `BLOCKED_NETWORKS` from `list` to `tuple` | LOW |
+| S5 | `web/app/api/resolve/route.ts:249-255` | Add debug-level logging when user API key overrides server env var | LOW |
+| S6 | `web/next.config.mjs:8` | Replace `hostname: "**"` with restricted allowlist or add tradeoff comment | LOW |
+
+### Wave 4: Quality & Scoring Fixes (Day 3-4)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| Q1 | `scripts/quality.py:20-21` | Remove `isinstance` branch returning perfect score. Extract magic numbers to named constants | MEDIUM |
+| Q2 | `scripts/quality.py` | Add docstring to `score_content()` | LOW |
+| Q3 | `scripts/resolve.py` | Fix `__all__` to exclude private names; keep underscores on `_is_rate_limited`/`_set_rate_limit` | LOW |
+| Q4 | `scripts/utils.py:295-314` | Rename `score_result()` to `score_domain_trust()` to differentiate from `quality.score_content()` | MEDIUM |
+| Q5 | `scripts/utils.py:516` | Remove dead `fragment` conditional | LOW |
+| Q6 | `scripts/utils.py:637-677` | Refactor `_detect_error_type` to pattern-list lookup | LOW |
+
+### Wave 5: Cross-Runtime Alignment (Day 4)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| R1 | `scripts/resolve.py:60` / `web/lib/resolvers/url.ts:5` | Align `MIN_CHARS` default to 200 everywhere | MEDIUM |
+| R2 | `scripts/quality.py:57` / `web/lib/quality.ts:38` / `cli/src/quality.rs` | Use profile-based configurable thresholds; stop hardcoding `0.65` | HIGH |
+| R3 | `web/lib/routing.ts:76-103` | Add `availableProviders: Set<string>` parameter to `planProviderOrder()` | MEDIUM |
+| R4 | `web/app/api/resolve/route.ts:147-177` | Refactor `resolveUrl()` to return `{ content, provider, latency, quality }` | HIGH |
+| R5 | `web/app/api/resolve/route.ts:21-68` | Pass `maxChars` to all provider functions | HIGH |
+| R6 | `cli/src/resolver/url.rs:152-154` | Apply `max_chars`/`min_chars` after Docling/OCR extraction | MEDIUM |
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Thread locks add latency to hot paths | Low | Use `threading.Lock` (not `RLock`); benchmark before/after |
+| Removing `isinstance` branch breaks test mocks | Medium | Update mocks to pass actual strings; add `TypeError` test |
+| Mistral SSRF check blocks legitimate URLs | Low | `is_safe_url` already allows all public IPs |
+| Aligning `MIN_CHARS` 50→200 rejects shorter web results | Low | 200 is already the Python default; web was under-filtering |
+| Refactoring `resolveUrl()` changes web API contract | Medium | Return type becomes object; update `page.tsx` consumer |
+
+## Postconditions
+
+1. All shared mutable state is thread-safe
+2. No monkey-patched module state — shared instances via `scripts/state.py`
+3. All `ProviderType` values reachable from `resolve_direct()`
+4. All provider exceptions logged (not silently swallowed)
+5. SSRF validation on every external API call path
+6. Quality scoring uses only real string input; no magic numbers
+7. Cross-runtime `MIN_CHARS`, quality thresholds, `maxChars` aligned
+8. `resolveUrl()` returns metadata; `safeFetch()` validates initial URL
+
+## Related ADRs
+
+- [ADR-009](009-cross-runtime-analysis.md) — Cross-runtime parity findings
+- [ADR-010](10-pr341-quality-gate-fixes.md) — Quality confidence gate
+- [ADR-014](014-architecture-and-parity.md) — DRY violations and cascade consolidation

--- a/.opencode/plans/013-test-coverage-and-ci-reliability.md
+++ b/.opencode/plans/013-test-coverage-and-ci-reliability.md
@@ -1,0 +1,120 @@
+# ADR-013: Test Coverage & CI Reliability
+
+**Date:** 2026-05-12
+**Status:** Proposed
+**Context:** The test suite has critical coverage gaps, misleading tests that pass without validating real behavior, and CI infrastructure issues that mask failures. Two core resolution paths (`resolve_url_stream` and `resolve_query_stream`) have zero working tests. 7 of 10 provider functions have no unit tests. The only existing integration tests replace core logic with stubs.
+
+---
+
+## Goal
+
+Achieve meaningful test coverage of all critical paths, eliminate misleading tests, fix CI infrastructure issues, and ensure quality gates actually catch regressions.
+
+---
+
+## GOAP Waves
+
+### Wave 1: Fix Misleading & Hollow Tests (Day 1)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| M1 | `tests/conftest.py:46-49` | Remove `should_call_llm_synthesis = lambda x: False` and `deterministic_merge = lambda x: "Merged content"` stubs. Add `conftest.py` fixtures that optionally mock synthesis but default to real behavior | HIGH |
+| M2 | `tests/conftest.py:54-71` | Remove `plan_provider_order` monkey-patch. Test the real routing logic; use `skip_providers` parameter for targeted tests instead of bypassing routing entirely | HIGH |
+| M3 | `tests/test_routing_foundation.py:371-439` | Delete `TestSynthesisGate._gate_decision()` re-implementation. Import and test the real `scripts/synthesis.synthesis_gate_decision()` function | HIGH |
+| M4 | `tests/test_routing_foundation.py:442-456` | Replace `test_gate_passed_logic` (which tests `0.85 >= 0.7`) with a test that calls `ResolutionBudget.is_expired()` and `synthesis_gate_decision()` | MEDIUM |
+| M5 | `test_quality_real.py:43-46` | Remove `test_score_content_non_string` test that validates a mock workaround. Add `pytest.raises(TypeError)` test for `None`/non-string input after Q1 fix removes the `isinstance` branch | MEDIUM |
+| M6 | `tests/test_ssrf_repro.py:18-22` | Add test that exercises real `is_safe_url()` and `validate_url()` logic without mocking `_safe_request`. Current test mocks the only meaningful code path | MEDIUM |
+| M7 | `tests/test_resolve.py:72,91` | Stop overriding `scripts.resolve._cache = None` which bypasses the conftest `MemoryCache` fixture | LOW |
+
+### Wave 2: Cover Critical Untested Paths (Day 2-3)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| C1 | `tests/test_url_resolve.py` (new) | Create test file for `resolve_url_stream()`: test concurrent futures, budget enforcement, quality gate early exit, negative cache recording, circuit breaker integration. Mock provider functions but exercise the real cascade logic | HIGH |
+| C2 | `tests/test_query_resolve.py` (new) | Create test file for `resolve_query_stream()`: same pattern as C1 — mock providers, exercise real cascade, budget, quality gate, negative cache, circuit breaker | HIGH |
+| C3 | `tests/test_providers.py` (new) | Add mocked unit tests for: `resolve_with_jina`, `resolve_with_exa`, `resolve_with_exa_mcp`, `resolve_with_tavily`, `resolve_with_serper`, `resolve_with_mistral_websearch`. Each should test: success path, timeout, rate limit response, invalid content | HIGH |
+| C4 | `tests/test_synthesis.py` (new) | Test real `synthesis.py` functions: `_content_similarity`, `_has_conflicts`, `_is_fragmented`, `deterministic_merge`, `synthesis_gate_decision`. Test edge cases: empty strings, duplicate results, fragmented content, all-same results | HIGH |
+| C5 | `tests/test_utils_critical.py` (new) | Test `extract_text_from_html()`, `compact_content()`, `is_safe_url()` (direct), `normalize_query()`, `validate_links()`, `score_domain_trust()` (renamed from `score_result`), `create_session_with_retry()` | MEDIUM |
+| C6 | `tests/test_models.py` (extend) | Add tests for `Profile.is_provider_allowed()`, `Profile.max_hops()`, `ProviderType.is_paid()`, `ProviderType.is_fast()`, `ResolvedResult.to_dict()`, `ResolveMetrics.record_provider()`, `ValidationResult` defaults | MEDIUM |
+| C7 | `tests/test_cli.py` (new) | Test `scripts/cli.py`: argument parsing, `--provider`, `--skip`, `--json`, `--profile` flags, output formatting | LOW |
+
+### Wave 3: Fix CI Infrastructure (Day 3-4)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| I1 | `.github/workflows/ci.yml:106` | Fix coverage upload condition: change `matrix.python-version == env.PYTHON_VERSION` to `${{ matrix.python-version == env.PYTHON_VERSION }}` — current YAML comparison never evaluates as an expression | HIGH |
+| I2 | `.github/workflows/gitleaks.yml:5-6` | Remove `master` and `develop` branch triggers; only `main` exists. Add `paths-ignore` for `*.md` if appropriate | MEDIUM |
+| I3 | `.github/workflows/gitleaks.yml:21` | Update `actions/checkout` from `v4.2.2` to `v6.0.2` to match all other workflows | MEDIUM |
+| I4 | `.github/workflows/ci.yml:69` | Install lint dependencies from `requirements.txt` or `pyproject.toml` instead of ad-hoc `pip install ruff black mypy types-requests` | MEDIUM |
+| I5 | `.pre-commit-config.yaml:34` | Change shellcheck severity from `warning` to `error` to match AGENTS.md policy | MEDIUM |
+| I6 | `web/package.json:51` | Fix `typescript: "^6.0.3"` to `"^5.x"` or valid version. TypeScript 6.x does not exist | HIGH |
+| I7 | `web/package.json:23` | Fix `next: "^16.2.6"` to a valid Next.js version. 16.x has not been released | HIGH |
+| I8 | `web/package.json:29/55` | Remove duplicate `overrides` key for `@ungap/structured-clone` | MEDIUM |
+
+### Wave 4: Fix Pre-commit Hooks & Config Consistency (Day 4)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| K1 | `scripts/setup-hooks.sh` | Replace minimal hook with the comprehensive `scripts/pre-commit-hook.sh` that runs `validate_docs.py --fix` then `quality_gate.sh`. Or source the comprehensive hook from `.githooks/` | MEDIUM |
+| K2 | `.githooks/pre-commit` | Verify this hook calls `quality_gate.sh` (it does). Add symlink from `.git/hooks/pre-commit` to `.githooks/pre-commit` in setup script | LOW |
+| K3 | `.pre-commit-config.yaml` | Remove the duplicate `quality_gate.sh` local hook since `.githooks/pre-commit` already calls it, OR keep only the pre-commit framework hook and remove `.githooks/pre-commit` | LOW |
+| K4 | `requirements.txt` | Reconcile with `pyproject.toml`: change `duckduckgo-search>=6.0.0` to `ddgs>=6.0.0` (correct package name). Remove `flake8` (redundant with `ruff`). Fix `mistralai` comment about PyPI removal | HIGH |
+| K5 | `pyproject.toml:16-18` | Add Python 3.13 classifier if CI tests it. Add `py313` to `black` target-version | MEDIUM |
+| K6 | `commitlint.config.cjs` | Add `type-enum` rule matching AGENTS.md allowed types: `build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test` | LOW |
+| K7 | `close-resolved-issues.yml:4` | Change `pull_request_target` to `pull_request` with explicit permission scope, or add `if: github.event.pull_request.merged == true` guard | MEDIUM |
+
+### Wave 5: Fix Flaky & Anti-Pattern Tests (Day 4-5)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| F1 | `tests/test_semantic_cache_bench.py:80-94` | Add `@pytest.mark.slow` marker. Increase latency thresholds for CI (300ms avg, 800ms max). Skip on CI unless `RUN_BENCH` env var is set | MEDIUM |
+| F2 | `tests/test_live_api_integrations.py` | Change `pytest.skip()` on `None` results to `pytest.xfail()` with reason. Distinguish "no API key" (skip) from "provider broken" (xfail) | MEDIUM |
+| F3 | `tests/test_routing_env_override.py:23-29` | Replace `importlib.reload(scripts.routing)` with `pytest.monkeypatch` for env var patching. Module reload can corrupt other tests | MEDIUM |
+| F4 | `tests/conftest.py:34-43` | Replace direct `_routing_memory.domain_stats.clear()` / `_circuit_breakers.breakers.clear()` / `_rate_limits.clear()` with proper fixtures using `monkeypatch` or autouse teardown | MEDIUM |
+| F5 | `tests/conftest.py:76-79` | Wrap restoration of `should_call_llm_synthesis`, `deterministic_merge`, `plan_provider_order` in `try/finally` to ensure cleanup even on exception | MEDIUM |
+| F6 | `tests/test_tiered_ttl.py:32-35` | Remove no-op `test_config_file_loading` or implement it properly | LOW |
+| F7 | `tests/bench_quality.py` | Move to `benchmarks/` directory. Add `@pytest.mark.benchmark` marker. Document that it's not a standard pytest target | LOW |
+| F8 | `tests/integration/test_cli_markdown.py:6` | Make `CLI_PATH` configurable via env var with sensible default for CI vs local development | LOW |
+| F9 | `.github/workflows/cleanup.yml:166` | Remove `continue-on-error: true` from quality gate step. Failures should be visible | MEDIUM |
+| F10 | `.github/workflows/nightly-bridge.yml:67-81` | Change auto-format push to create a PR instead of pushing directly to `main`. Use `create-pull-request` action | MEDIUM |
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Removing conftest stubs breaks many existing tests | High | Stage removal: first add real tests, then disable stubs, then remove |
+| Adding stream resolution tests requires mocking `concurrent.futures` | Medium | Use real `ThreadPoolExecutor` with mocked provider functions; test budget/quality gates |
+| CI coverage fix may reveal previously hidden failures | Medium | Fix failures before enabling coverage enforcement |
+| Reconciling dependencies may break other packages | Medium | Test in CI with `pip install -e .` from clean venv |
+
+## Postconditions
+
+1. `resolve_url_stream` and `resolve_query_stream` have working test coverage
+2. All 10 provider functions have at least mocked unit tests
+3. `synthesis.py` tested with real functions (not re-implementations)
+4. CI coverage uploads succeed and report real coverage
+5. Web `package.json` has valid dependency versions
+6. Three pre-commit hooks consolidated to one path
+7. Shellcheck severity matches AGENTS.md policy (`error`)
+8. No no-op tests; no `pass` test bodies
+9. Flaky tests marked `@pytest.mark.slow` with appropriate thresholds
+
+## Related ADRs
+
+- [ADR-012](012-correctness-and-safety-fixes.md) — Correctness fixes that enable meaningful testing
+- [ADR-014](014-architecture-and-parity.md) — Architecture consolidation that reduces test surface area
+- [ADR-009](009-cross-runtime-analysis.md) — Cross-runtime parity findings
+
+---
+
+## Summary Table
+
+| # | Finding | Severity | Wave | Effort |
+|---|---------|----------|------|--------|
+| M1-M7 | Misleading/hollow tests (7 items) | HIGH | 1 | M |
+| C1-C7 | Uncovered critical paths (7 items) | HIGH | 2 | L |
+| I1-I8 | CI infrastructure fixes (8 items) | HIGH-MEDIUM | 3 | S |
+| K1-K7 | Pre-commit & config consistency (7 items) | MEDIUM-LOW | 4 | S |
+| F1-F10 | Flaky tests & anti-patterns (10 items) | MEDIUM | 5 | S |

--- a/.opencode/plans/014-architecture-and-parity.md
+++ b/.opencode/plans/014-architecture-and-parity.md
@@ -1,0 +1,122 @@
+# ADR-014: Architecture & Cross-Runtime Parity
+
+**Date:** 2026-05-12
+**Status:** Proposed
+**Context:** The codebase has significant DRY violations (~310 lines of near-identical code between `_url_resolve.py` and `_query_resolve.py`), triple-defined constants, circular import workarounds, and cross-runtime divergences in budget profiles, quality thresholds, and provider coverage. These make the codebase harder to maintain and increase the risk of cross-platform bugs.
+
+---
+
+## Goal
+
+Consolidate duplicated logic, establish single-source-of-truth patterns for configuration and constants, and bring Python/Rust/Web runtimes into structural parity.
+
+---
+
+## GOAP Waves
+
+### Wave 1: Extract Shared Constants & State (Day 1)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| A1 | `scripts/constants.py` (new) | Create single-source module for `MAX_CHARS`, `MIN_CHARS`, `DEFAULT_TIMEOUT`, `CACHE_DIR`, `CACHE_TTL`, `ACCEPTABLE_QUALITY_THRESHOLD`, `TOO_SHORT_THRESHOLD`, and all other shared constants. Import from here everywhere | HIGH |
+| A2 | `scripts/resolve.py` | Remove `MAX_CHARS`, `MIN_CHARS`, `DEFAULT_TIMEOUT` definitions (lines 59-61). Import from `scripts.constants` | HIGH |
+| A3 | `scripts/utils.py` | Remove `MAX_CHARS`, `DEFAULT_TIMEOUT`, `CACHE_DIR`, `CACHE_TTL` definitions (lines 27-30). Import from `scripts.constants` | HIGH |
+| A4 | `scripts/providers_impl.py` | Remove `MAX_CHARS`, `MIN_CHARS`, `DEFAULT_TIMEOUT` definitions (lines 24-26). Import from `scripts.constants` | HIGH |
+| A5 | `scripts/state.py` (new) | Create module holding shared instances: `_circuit_breakers`, `_routing_memory`, initialize once. Both `_url_resolve.py` and `_query_resolve.py` import from here. Eliminates monkey-patching in `resolve.py` | HIGH |
+| A6 | `scripts/resolve.py` | Remove monkey-patching lines 84-87. Import shared state from `scripts.state` instead | HIGH |
+| A7 | `scripts/_url_resolve.py`, `scripts/_query_resolve.py` | Remove module-level `_circuit_breakers` and `_routing_memory` creation (lines 44-45 in each). Import from `scripts.state` | HIGH |
+| A8 | `scripts/semantic_cache.py:478-485` | Move `ENABLE_SEMANTIC_CACHE`, `SEMANTIC_CACHE_THRESHOLD`, `SEMANTIC_CACHE_MAX_ENTRIES` env var reads to `scripts.constants`. Semantic cache module imports from constants | MEDIUM |
+
+### Wave 2: Consolidate Cascade Logic (Day 2-3)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| D1 | `scripts/cascade.py` (new) | Extract shared cascade function from the duplicated logic in `_url_resolve.py:166-298` and `_query_resolve.py:146-246`. The function takes: provider_map, eligible_providers, budget, callbacks (on_result, on_quality_fail, on_provider_skip), and routing_type ("url"/"query"). Returns `list[ResolvedResult]` or generator | HIGH |
+| D2 | `scripts/_url_resolve.py` | Replace ~133 lines of cascade loop with call to `cascade.run_cascade()`. Keep URL-specific handling: `fetch_llms_txt` special case, `compact_content` call, domain stats recording | HIGH |
+| D3 | `scripts/_query_resolve.py` | Replace ~100 lines of cascade loop with call to `cascade.run_cascade()`. Keep query-specific handling: query string recording, no `compact_content` | HIGH |
+| D4 | `scripts/cascade.py` (new) | Extract shared `_check_semantic_cache()` and `_store_in_semantic_cache()` from `_url_resolve.py:48-84` and `_query_resolve.py:44-80` (37 identical lines). Single implementation | HIGH |
+| D5 | `scripts/_url_resolve.py`, `scripts/_query_resolve.py` | Replace inline semantic cache functions with imports from `scripts.cascade` | MEDIUM |
+| D6 | `scripts/cascade.py` (new) | Extract shared `ResolutionBudget` construction logic from `_url_resolve.py:114-123` and `_query_resolve.py:116-125` | MEDIUM |
+| D7 | `scripts/resolve.py:155-156` | Inline `synthesize_results()` call or remove the re-export wrapper that adds no value | LOW |
+
+### Wave 3: DRY Within Modules (Day 3)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| R1 | `scripts/doc_models.py`, `scripts/doc_checkers_1.py`, `scripts/doc_checkers_2.py`, `scripts/doc_fixers.py` | Consolidate `REPO_ROOT` definition into `scripts/constants.py`. Remove 3 duplicate definitions | LOW |
+| R2 | `scripts/doc_models.py:7-9` | Remove unused `EXTERNAL_PACKAGES` frozenset | LOW |
+| R3 | `scripts/doc_fixers.py` | Remove or implement 3 stub fixers: `fix_python_cli`, `fix_duplicate_links`, `fix_repo_trees` (all return 0 with no logic) | LOW |
+| R4 | `scripts/utils.py:333-396` | Move `EnhancedHTMLParser` class definition out of `extract_text_from_html()` to module level. It's recreated on every call | MEDIUM |
+| R5 | `scripts/cache_negative.py:49-51` | Move deferred `from scripts.utils import get_ttl` to module top level. If circular import exists, refactor the dependency | LOW |
+| R6 | `scripts/quality.py` | Add `from __future__ import annotations` and full type annotations to `score_content()` signature and return type | LOW |
+| R7 | `scripts/synthesis.py` | Replace `import datetime` with `from datetime import date`. Replace unnamed magic numbers with constants: `SIMILARITY_TRUNCATION=2000`, `CONFLICT_THRESHOLD=0.2`, `FRAGMENT_MIN_CHARS=500`, `MIN_TOTAL_CONTENT=1000`, `SYNTHESIS_QUALITY_THRESHOLD=0.65` | MEDIUM |
+
+### Wave 4: Unify Budget Profiles & Quality Thresholds (Day 4)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| U1 | `scripts/routing.py:48-77` | Convert `PROFILE_BUDGETS` dict to a `TypedDict` or dataclass `BudgetProfile` with fields: `max_provider_attempts`, `max_paid_attempts`, `max_total_latency_ms`, `min_free_quality_to_skip_paid`, `allow_parallel`. Replace `budget_data["max_provider_attempts"]` lookups with typed attribute access | HIGH |
+| U2 | `web/app/constants.ts:23-29` | Align `PROFILES.balanced` with Python/Rust defaults: `maxProviderAttempts: 4` (currently 6), `maxPaidAttempts: 1` (currently 2), `maxTotalLatencyMs: 9000` (currently 12000). These diverge significantly | HIGH |
+| U3 | `scripts/constants.py` | Define `MIN_FREE_QUALITY_TO_SKIP_PAID = 0.70`, `MIN_CHARS_DEFAULT = 200`, `ACCEPTABLE_QUALITY_THRESHOLD = 0.65`. Import in `quality.py`, `routing.py`, `_url_resolve.py`, `_query_resolve.py` | MEDIUM |
+| U4 | `web/lib/quality.ts` | Replace hardcoded `0.65` with `ACCEPTABLE_QUALITY_THRESHOLD` constant imported from config. Replace hardcoded `50` with `MIN_CHARS_DEFAULT = 200` | MEDIUM |
+| U5 | `cli/src/routing.rs:204-229` | Document that Rust profile defaults already use configurable thresholds. Ensure Python and Web read from the same config source or shared defaults | LOW |
+| U6 | `scripts/routing.py:11` | Move `DEFAULT_MIN_FREE_QUALITY = float(os.getenv("DO_WDR_MIN_FREE_QUALITY_TO_SKIP_PAID", "0.70"))` to `scripts/constants.py`. Read env var at module import time | LOW |
+
+### Wave 5: Resolve Circular Dependencies & Dead Code (Day 5)
+
+| ID | File | Action | Severity |
+|----|------|--------|----------|
+| C1 | `scripts/utils.py:558-563` | Break circular import: `_get_cache_proxy` imports `scripts.resolve` which imports from `scripts.utils`. Refactor by extracting cache management to `scripts/cache_manager.py` that doesn't import from resolve | HIGH |
+| C2 | `scripts/_url_resolve.py:162` | Remove circular import workaround `from scripts import resolve as resolve_module` inside function body. After A5/C1, shared state and cache are in separate modules, so the circular dependency is eliminated | MEDIUM |
+| C3 | `scripts/_query_resolve.py:142` | Same as C2 — remove inner-function import of resolve module | MEDIUM |
+| C4 | `scripts/routing_memory.py:85-87` | Remove backward-compat `rank()` wrapper that calls `rank_providers()`. Use `rank_providers()` directly | LOW |
+| C5 | `scripts/models.py:103` | Add `to_dict()` method to `ValidationResult` for consistency with `ResolvedResult.to_dict()` | LOW |
+| C6 | `scripts/models.py:122` | Wire `ResolveMetrics.cascade_depth` — increment in cascade loop or remove the field if unused | LOW |
+| C7 | `cli/src/output.rs:32-40` | Remove dead `JsonOutput::error()` method (marked `#[allow(dead_code)]`, `_msg` parameter unused, always returns zero-score empty result) | LOW |
+| C8 | `cli/src/output.rs:51-77` | Remove dead `TextOutput` struct and methods (`print_result`, `print_error`, `print_info`, `print_success`) — none are called in `main.rs` | LOW |
+| C9 | `cli/src/semantic_cache.rs:544-551` | Fix `stats()` to return real entries/hit_rate when `semantic-cache` feature is enabled instead of always returning zeros | MEDIUM |
+| C10 | `web/package.json:51` | Already fixed in ADR-013 I6 — ensure TypeScript version is valid (`^5.x`) | N/A |
+
+---
+
+## Risk Assessment
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Extracting cascade logic may break URL-vs-query differences | High | Keep URL-specific and query-specific callbacks/hooks in the shared `run_cascade()` function; unit test both paths thoroughly |
+| Moving constants to new module changes import paths across codebase | Medium | Update all imports in one commit; run `quality_gate.sh` and full test suite |
+| Breaking circular imports requires careful reordering | Medium | `scripts.constants` has no imports from `scripts.*`; `scripts.state` only imports `circuit_breaker` and `routing_memory`; both are leaf modules |
+| Aligning budget profiles changes web behavior | Low | Web was using more generous defaults (6 attempts, 12s); the stricter Python/Rust defaults (4 attempts, 9s) are the intended baseline |
+| Removing `conftest.py` stubs requires new tests first | Medium | Wave 2 (ADR-013) must add real tests before Wave 1 (this ADR) can safely remove stubs |
+
+## Postconditions
+
+1. All configuration constants defined once in `scripts/constants.py`
+2. Shared mutable state defined once in `scripts/state.py`
+3. Cascade logic in single `scripts/cascade.py` module (~200 lines vs ~310 duplicated)
+4. No circular imports — `constants` and `state` are leaf modules
+5. No monkey-patching of module-level state
+6. Budget profiles use typed dataclass, aligned across all 3 runtimes
+7. Quality thresholds are configurable via constants, not hardcoded
+8. Dead code removed (stub fixers, unused dataclasses, dead CLI output structs)
+9. All `REPO_ROOT` references point to single source
+10. `semantic_cache.py` env vars centralized in `constants.py`
+
+## Related ADRs
+
+- [ADR-012](012-correctness-and-safety-fixes.md) — Bug fixes and security hardening (wave 1 sets up `scripts/constants.py` and `scripts/state.py`)
+- [ADR-013](013-test-coverage-and-ci-reliability.md) — Test coverage (depends on cascade consolidation for meaningful stream tests)
+- [ADR-001](01-architecture-improvements.md) — Architecture improvements (async migration, Provider trait, config consolidation)
+- [ADR-003](03-performance-optimization.md) — Performance optimization (shared HTTP session requires `state.py`)
+
+---
+
+## Summary Table
+
+| # | Finding | Severity | Wave | Effort |
+|---|---------|----------|------|--------|
+| A1-A8 | Triple-defined constants, monkey-patching, env var duplication | HIGH | 1 | M |
+| D1-D7 | ~310 lines duplicated cascade logic, semantic cache, budget construction | HIGH | 2 | L |
+| R1-R7 | Intra-module DRY violations, dead code, magic numbers | MEDIUM | 3 | S |
+| U1-U6 | Budget profile divergence, hardcoded quality thresholds | HIGH | 4 | M |
+| C1-C10 | Circular imports, dead code across runtimes | MEDIUM | 5 | M |

--- a/plans/17-NIGHTLY-BRIDGE-PR.md
+++ b/plans/17-NIGHTLY-BRIDGE-PR.md
@@ -1,0 +1,87 @@
+# ADR-015 + GOAP: Nightly Bridge Push → PR Workflow
+
+> Generated 2026-05-13. Resolves nightly CI failure caused by direct push to `main`.
+
+## ADR-015: Nightly Bridge Push → PR Workflow
+
+### Status
+
+PROPOSED → IMPLEMENTING
+
+### Context
+
+The `nightly-bridge.yml` workflow runs formatting (ruff, black, cargo fmt) and
+attempts to commit + push the result directly to `main`. This violates two
+GitHub repository branch protection rules:
+1. **Changes must be made through a pull request** — no direct pushes to `main`
+2. **4 of 4 required status checks are expected** — CI must pass before merge
+
+This caused the 2026-05-13 nightly run to fail:
+```
+remote: error: GH013: Repository rule violations found for refs/heads/main.
+remote: - 4 of 4 required status checks are expected.
+remote: - Changes must be made through a pull request.
+```
+
+### Decision
+
+Replace the direct `git push` to `main` with a PR-based workflow:
+1. Create a feature branch with a datestamp (`chore/nightly-format-YYYYMMDD`)
+2. Commit formatting changes to that branch
+3. Push the branch
+4. Create a PR via `gh pr create` targeting `main`
+5. Do NOT auto-merge — let CI validate formatting changes
+
+### Consequences
+
+- **Positive**: Respects branch protection rules; CI validates formatting on the PR;
+  PR audit trail for all automated changes.
+- **Negative**: Creates PR noise (one per nightly if formatting drifts); requires
+  manual merge or auto-merge with branch protection.
+- **Mitigation**: Once the one unformatted file is fixed, most nightlies will
+  have zero changes, producing zero PRs.
+
+### Compliance
+
+- Aligns with `AGENTS.md` policy: "Never commit to main"
+- Uses existing `GITHUB_TOKEN` via `gh` CLI (already installed on GitHub runners)
+- Adds `pull-requests: write` permission to the workflow
+
+---
+
+## GOAP Plan: Nightly Bridge PR Fix
+
+### Goal
+
+Nightly formatting workflow creates a PR instead of pushing directly to `main`,
+eliminating the repository rule violation failure.
+
+### Preconditions
+
+- `gh` CLI is available on the GitHub Actions runner (default)
+- `GITHUB_TOKEN` has `contents: write` + `pull-requests: write` scopes
+- Repository rules remain unchanged (no direct push)
+
+### Actions
+
+| # | Task | File | Effort |
+|---|------|------|--------|
+| A1 | Create ADR-015 + GOAP plan | `plans/17-NIGHTLY-BRIDGE-PR.md` | S |
+| A2 | Update plans/README.md to reference new plan | `plans/README.md` | S |
+| A3 | Fix nightly-bridge.yml push → PR workflow | `.github/workflows/nightly-bridge.yml` | S |
+| A4 | Fix `tests/test_routing_foundation.py` ruff format | `tests/test_routing_foundation.py` | S |
+
+### Postconditions
+
+1. Nightly formatting changes are committed to a branch and submitted as a PR
+2. No more `GH013: Repository rule violations found` failures
+3. Formatting drift is visible as open PRs instead of silent pushes
+4. `tests/test_routing_foundation.py` passes `ruff format .` without changes
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| PR explosion if formatting constantly drifts | Fix the root cause (one unformatted file); most nightlies will produce 0 diffs |
+| `gh pr create` may fail if no changes | Step guarded by `git diff --cached --quiet` check |
+| PR requires manual merge | Add `--auto` with `--squash` to auto-merge after CI passes in a future iteration |

--- a/plans/README.md
+++ b/plans/README.md
@@ -14,6 +14,7 @@
 | 012 | [Correctness & Safety](012-correctness-and-safety-fixes.md) | Thread safety, SSRF, provider gaps | Wave 1 ✅ Wave 4 PENDING |
 | 013 | [Test Coverage & CI](013-test-coverage-and-ci-reliability.md) | Misleading tests, CI fixes | Wave 1b ✅ Wave 2,5 PENDING |
 | 014 | [Architecture & Parity](014-architecture-and-parity.md) | DRY consolidation, constants, dead code | Wave 3,6 PENDING |
+| 015 | [Nightly Bridge PR](17-NIGHTLY-BRIDGE-PR.md) | Nightly workflow push→PR | PROPOSED → IMPLEMENTING |
 
 ## Implementation Waves
 
@@ -44,6 +45,7 @@
 | 11 | [Cache Pre-warming](11-cache-prewarming.md) | CLI + web prewarm (Scope creep extraction) | PENDING |
 | 15 | [Next Phase](15-GOAP-NEXT-PHASE.md) | Wave 2-6 + AUDIT P0/P1 items | Superseded (see 16) |
 | 16 | [GOAP Waves 2-6](16-GOAP-WAVE2-6.md) | CI, constants, quality, splits, tests, parity | Active plan |
+| 17 | [Nightly Bridge PR](17-NIGHTLY-BRIDGE-PR.md) | ADR-015 + GOAP: nightly push→PR fix | Active plan |
 
 ## Executed Plans (Completed)
 
@@ -52,3 +54,4 @@
 | [CI_FIX.md](CI_FIX.md) | npm peer deps + libsql fix |
 | [ESLINT_CONFIG_UPDATE.md](ESLINT_CONFIG_UPDATE.md) | ESLint 2026 config |
 | [GOAP_FOLLOWUP.md](GOAP_FOLLOWUP.md) | ADR-012/013/014 wave tracking |
+| [17-NIGHTLY-BRIDGE-PR.md](17-NIGHTLY-BRIDGE-PR.md) | ADR-015 + GOAP: nightly push→PR fix |

--- a/tests/test_routing_foundation.py
+++ b/tests/test_routing_foundation.py
@@ -467,7 +467,6 @@ class TestQualityGate:
             patch("scripts.routing.plan_provider_order", return_value=["exa_mcp", "exa"]),
             patch("scripts.resolve._get_executor") as mock_executor,
         ):
-
             mock_cb.is_open.return_value = False
             mock_rm.get_p75_latency.return_value = 100
 


### PR DESCRIPTION
## Summary
- Fix nightly-bridge workflow failing due to branch protection rules (direct push to main rejected)
- Switch from `git push` to `gh pr create` on a dated branch
- Add `pull-requests: write` permission to the workflow
- Fix underlying ruff formatting drift in `tests/test_routing_foundation.py` (root cause)
- Add ADR-015 + GOAP plan in `plans/17-NIGHTLY-BRIDGE-PR.md`

## Testing
- `ruff format .` is clean (0 files changed)
- Workflow triggers via schedule on main once merged