### PR TITLE
Implement rate limiting for resolve endpoint

### DIFF
--- a/web/app/api/resolve/route.ts
+++ b/web/app/api/resolve/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { ResolutionBudget, planProviderOrder, detectJsHeavy, isPaidProvider } from "@/lib/routing";
 import { CircuitBreakerRegistry } from "@/lib/circuit-breaker";
 import { scoreContent, QualityScore } from "@/lib/quality";
+import { checkRateLimit, getClientIdentifier } from "@/lib/rate-limit";
 import * as cache from "@/lib/cache";
 import { save as saveRecord } from "@/lib/records";
 import { Logger } from "@/lib/log";
@@ -204,6 +205,13 @@ function normalizeQueryProviders(providerIds: string[], keys: ProviderKeys): str
 }
 
 export async function POST(request: NextRequest) {
+  const identifier = getClientIdentifier(request);
+  const { allowed } = checkRateLimit(identifier);
+
+  if (!allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const log = new Logger();
   try {
     const body = await request.json();

--- a/web/app/api/resolve/route.ts
+++ b/web/app/api/resolve/route.ts
@@ -206,7 +206,7 @@ function normalizeQueryProviders(providerIds: string[], keys: ProviderKeys): str
 
 export async function POST(request: NextRequest) {
   const identifier = getClientIdentifier(request);
-  const { allowed } = checkRateLimit(identifier);
+  const { allowed } = await checkRateLimit(identifier);
 
   if (!allowed) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });

--- a/web/app/api/resolve/route.ts
+++ b/web/app/api/resolve/route.ts
@@ -206,7 +206,7 @@ function normalizeQueryProviders(providerIds: string[], keys: ProviderKeys): str
 
 export async function POST(request: NextRequest) {
   const identifier = getClientIdentifier(request);
-  const { allowed } = await checkRateLimit(identifier);
+  const { allowed } = checkRateLimit(identifier);
 
   if (!allowed) {
     return NextResponse.json({ error: "Too many requests" }, { status: 429 });

--- a/web/tests/api/resolve-rate-limit.test.ts
+++ b/web/tests/api/resolve-rate-limit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../../app/api/resolve/route";
+import * as rateLimit from "../../lib/rate-limit";
+
+// Mock the rate limit module
+vi.mock("../../lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+  getClientIdentifier: vi.fn(),
+}));
+
+// Mock cache and records to avoid external dependencies or side effects
+vi.mock("../../lib/cache", () => ({
+  get: vi.fn().mockResolvedValue(null),
+  set: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../lib/records", () => ({
+  save: vi.fn(),
+}));
+
+describe("POST /api/resolve rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 429 when rate limit is exceeded", async () => {
+    // Setup mock to return blocked
+    vi.mocked(rateLimit.getClientIdentifier).mockReturnValue("test-ip");
+    vi.mocked(rateLimit.checkRateLimit).mockReturnValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 60000,
+    });
+
+    const request = new NextRequest("http://localhost/api/resolve", {
+      method: "POST",
+      body: JSON.stringify({ query: "test" }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(429);
+    const data = await response.json();
+    expect(data.error).toBe("Too many requests");
+
+    // Ensure checkRateLimit was called with correct identifier
+    expect(rateLimit.getClientIdentifier).toHaveBeenCalledWith(request);
+    expect(rateLimit.checkRateLimit).toHaveBeenCalledWith("test-ip");
+  });
+
+  it("proceeds normally when rate limit is not exceeded", async () => {
+    // Setup mock to return allowed
+    vi.mocked(rateLimit.getClientIdentifier).mockReturnValue("test-ip");
+    vi.mocked(rateLimit.checkRateLimit).mockReturnValue({
+      allowed: true,
+      remaining: 29,
+      resetAt: Date.now() + 60000,
+    });
+
+    // We don't need to mock the entire resolve cascade, just verify it gets past the rate limit check.
+    // Since we didn't mock queryProviders/urlProviders, it will likely fail later with "No search results found"
+    // which is fine as long as it's not a 429.
+
+    const request = new NextRequest("http://localhost/api/resolve", {
+      method: "POST",
+      body: JSON.stringify({ query: "test" }),
+    });
+
+    const response = await POST(request);
+
+    // It should NOT be 429
+    expect(response.status).not.toBe(429);
+
+    // Verify rate limit was checked
+    expect(rateLimit.checkRateLimit).toHaveBeenCalledWith("test-ip");
+  });
+});

--- a/web/tests/rate-limit.test.ts
+++ b/web/tests/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from "vitest";
-import { checkRateLimit, clearRateLimits, getRateLimitStats, cleanupExpiredEntries } from "../lib/rate-limit";
+import { checkRateLimit, clearRateLimits, getRateLimitStats, cleanupExpiredEntries, getClientIdentifier } from "../lib/rate-limit";
 
 describe("rate limiting", () => {
   beforeEach(() => {
@@ -76,6 +76,31 @@ describe("rate limiting", () => {
 
       const stats = getRateLimitStats();
       expect(stats.totalEntries).toBe(0);
+    });
+  });
+
+  describe("getClientIdentifier", () => {
+    it("prioritizes x-forwarded-for over x-real-ip", () => {
+      const headers = new Headers({
+        "x-forwarded-for": "1.2.3.4, 5.6.7.8",
+        "x-real-ip": "9.9.9.9",
+      });
+      const request = { headers } as unknown as Request;
+      expect(getClientIdentifier(request)).toBe("1.2.3.4");
+    });
+
+    it("uses x-real-ip if x-forwarded-for is missing", () => {
+      const headers = new Headers({
+        "x-real-ip": "9.9.9.9",
+      });
+      const request = { headers } as unknown as Request;
+      expect(getClientIdentifier(request)).toBe("9.9.9.9");
+    });
+
+    it("returns 'unknown' if no IP headers are present", () => {
+      const headers = new Headers();
+      const request = { headers } as unknown as Request;
+      expect(getClientIdentifier(request)).toBe("unknown");
     });
   });
 });

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
   test: {
+    alias: {
+      "@": path.resolve(__dirname, "./"),
+    },
     globals: true,
     environment: "node",
     include: ["tests/**/*.test.ts"],


### PR DESCRIPTION
Added rate limiting to the POST /api/resolve endpoint to prevent abuse and DoS attacks. The rate limiter uses the client's IP address (extracted from x-forwarded-for or x-real-ip) and allows 30 requests per minute by default.

---
*PR created automatically by Jules for task [17701289240816369865](https://jules.google.com/task/17701289240816369865) started by @d-oit*