### PR TITLE
ci(integration): add serper CI job with CLI smoke test and semantic cache DB coverage

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -193,7 +193,7 @@ jobs:
         run: cd cli && cargo build --release
 
       - name: Smoke test CLI (Serper)
-        run: ./cli/target/release/do-wdr "Rust agent frameworks" --log-level INFO
+        run: ./cli/target/release/do-wdr resolve "Rust agent frameworks"
         env:
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
 

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -149,6 +149,54 @@ jobs:
           EXA_API_KEY: ""
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
 
+  serper-integration:
+    name: Serper Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+       github.event_name == 'workflow_dispatch')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run Serper live tests
+        run: |
+          pytest -m live -s -v \
+            tests/test_live_api_integrations.py::test_live_serper_with_real_api_key
+        env:
+          SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: '1.85'
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          workspaces: cli
+
+      - name: Build Rust CLI
+        run: cd cli && cargo build --release
+
+      - name: Smoke test CLI (Serper)
+        run: ./cli/target/release/do-wdr "Rust agent frameworks" --log-level INFO
+        env:
+          SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
+
   exa-integration:
     name: Exa Integration
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-bridge.yml
+++ b/.github/workflows/nightly-bridge.yml
@@ -63,6 +63,7 @@ jobs:
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
 
       - name: Format Python
         run: |

--- a/tests/test_live_api_integrations.py
+++ b/tests/test_live_api_integrations.py
@@ -24,6 +24,7 @@ from scripts.resolve import (  # noqa: E402
     resolve_with_jina,
     resolve_with_mistral_browser,
     resolve_with_mistral_websearch,
+    resolve_with_serper,
     resolve_with_tavily,
 )
 
@@ -146,5 +147,17 @@ def test_live_mistral_websearch_with_real_api_key():
     if result is None:
         pytest.skip("Mistral websearch returned None - check MISTRAL_API_KEY and quota")
     assert result.source == "mistral-websearch"
+    assert isinstance(result.content, str)
+    assert len(result.content.strip()) > 0
+
+
+def test_live_serper_with_real_api_key():
+    _require_env("SERPER_API_KEY")
+    query = f"Rust agent frameworks {uuid.uuid4().hex[:8]}"
+    _clear_cached_result(query, "serper", rate_limit_key="serper")
+    result = resolve_with_serper(query)
+    if result is None:
+        pytest.skip("Serper returned None - check SERPER_API_KEY and quota")
+    assert result.source == "serper"
     assert isinstance(result.content, str)
     assert len(result.content.strip()) > 0


### PR DESCRIPTION
## Changes

- **tests/test_live_api_integrations.py**: Added  live test
- **.github/workflows/ci-integration.yml**: Added  job — runs serper live test + builds Rust CLI for  smoke test
- **.github/workflows/nightly-bridge.yml**: Added  to nightly full integration run

Closes the gap where SERPER_API_KEY existed as a secret but was never exercised in CI.