### PR TITLE
Improve Rust CLI Markdown Parsing for LaTeX and Code Blocks

### DIFF
--- a/cli/src/providers/direct_fetch.rs
+++ b/cli/src/providers/direct_fetch.rs
@@ -181,7 +181,7 @@ fn strip_html(html: &str) -> String {
             if tag_name == "script" || tag_name == "style" {
                 if is_closing {
                     skip_content_depth = skip_content_depth.saturating_sub(1);
-                } else if !tag_lower.ends_with('/') {
+                } else if !tag_lower.trim().ends_with('/') {
                     skip_content_depth += 1;
                 }
             } else if skip_content_depth == 0 {

--- a/cli/src/providers/direct_fetch.rs
+++ b/cli/src/providers/direct_fetch.rs
@@ -102,8 +102,50 @@ fn decode_entities(text: &str) -> String {
         .replace("&#x27;", "'")
         .replace("&#39;", "'")
         .replace("&nbsp;", " ")
+        .replace("&#8288;", "") // word joiner
         .replace("&amp;", "&") // Ampersand last to avoid double-unescaping
         .replace("\u{2060}", "") // Remove word joiner
+}
+
+/// Get an attribute value from a tag string
+fn get_attribute(tag_content: &str, attr_name: &str) -> Option<String> {
+    let lower = tag_content.to_lowercase();
+    let pattern = format!("{}=", attr_name);
+    if let Some(start) = lower.find(&pattern) {
+        let value_part = &tag_content[start + pattern.len()..];
+        if value_part.starts_with('"') {
+            if let Some(end) = value_part[1..].find('"') {
+                return Some(value_part[1..1 + end].to_string());
+            }
+        } else if value_part.starts_with('\'') {
+            if let Some(end) = value_part[1..].find('\'') {
+                return Some(value_part[1..1 + end].to_string());
+            }
+        } else {
+            // Unquoted attribute
+            let end = value_part
+                .find(|c: char| c.is_whitespace() || c == '/' || c == '>')
+                .unwrap_or(value_part.len());
+            return Some(value_part[..end].to_string());
+        }
+    }
+    None
+}
+
+/// Parse language hint from class attribute
+fn parse_language_hint(class_attr: &str) -> Option<String> {
+    for part in class_attr.split_whitespace() {
+        if let Some(lang) = part.strip_prefix("language-") {
+            return Some(lang.to_string());
+        }
+        if let Some(lang) = part.strip_prefix("lang-") {
+            return Some(lang.to_string());
+        }
+        if part == "rust" {
+            return Some("rust".to_string());
+        }
+    }
+    None
 }
 
 /// Strip HTML tags and convert to plain text with basic formatting
@@ -112,6 +154,7 @@ fn strip_html(html: &str) -> String {
     let mut in_tag = false;
     let mut current_tag = String::new();
     let mut skip_content_depth: usize = 0;
+    let mut in_pre = false;
 
     let block_tags: HashSet<&str> = [
         "p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "tr", "pre", "br", "article",
@@ -138,7 +181,7 @@ fn strip_html(html: &str) -> String {
             if tag_name == "script" || tag_name == "style" {
                 if is_closing {
                     skip_content_depth = skip_content_depth.saturating_sub(1);
-                } else {
+                } else if !tag_lower.ends_with('/') {
                     skip_content_depth += 1;
                 }
             } else if skip_content_depth == 0 {
@@ -151,16 +194,38 @@ fn strip_html(html: &str) -> String {
                         result.push('\n');
                     }
                     if tag_name == "code" {
-                        result.push('`');
+                        if !in_pre {
+                            result.push('`');
+                        }
                     } else if tag_name == "pre" {
-                        result.push_str("\n```\n");
+                        in_pre = true;
+                        let lang = get_attribute(&current_tag, "class")
+                            .and_then(|c| parse_language_hint(&c))
+                            .unwrap_or_default();
+                        result.push_str("\n```");
+                        result.push_str(&lang);
+                        result.push('\n');
+                    } else if tag_name == "img" {
+                        if let Some(alt) = get_attribute(&current_tag, "alt") {
+                            if !alt.is_empty() {
+                                result.push(' ');
+                                result.push_str(&alt);
+                                result.push(' ');
+                            }
+                        }
                     }
                 } else {
                     // Closing tags
                     if tag_name == "code" {
-                        result.push('`');
+                        if !in_pre {
+                            result.push('`');
+                        }
                     } else if tag_name == "pre" {
-                        result.push_str("\n```\n");
+                        in_pre = false;
+                        if !result.ends_with('\n') {
+                            result.push('\n');
+                        }
+                        result.push_str("```\n");
                     } else if block_tags.contains(tag_name)
                         && !result.is_empty()
                         && !result.ends_with('\n')
@@ -226,5 +291,20 @@ mod tests {
         assert!(result.contains("`fn main()`"));
         assert!(result.contains("```"));
         assert!(result.contains("println!(\"Hi\");"));
+    }
+
+    #[test]
+    fn test_code_blocks_with_lang() {
+        let html = "<pre class=\"language-rust\"><code>fn main() {}</code></pre>";
+        let result = strip_html(html);
+        assert!(result.contains("```rust"));
+        assert!(!result.contains("`` ` ``")); // Ensure no double backticks
+    }
+
+    #[test]
+    fn test_img_alt() {
+        let html = "<img src=\"math.svg\" alt=\"x^2 + y^2 = z^2\">";
+        let result = strip_html(html);
+        assert!(result.contains("x^2 + y^2 = z^2"));
     }
 }

--- a/cli/src/providers/direct_fetch.rs
+++ b/cli/src/providers/direct_fetch.rs
@@ -113,13 +113,13 @@ fn get_attribute(tag_content: &str, attr_name: &str) -> Option<String> {
     let pattern = format!("{}=", attr_name);
     if let Some(start) = lower.find(&pattern) {
         let value_part = &tag_content[start + pattern.len()..];
-        if value_part.starts_with('"') {
-            if let Some(end) = value_part[1..].find('"') {
-                return Some(value_part[1..1 + end].to_string());
+        if let Some(stripped) = value_part.strip_prefix('"') {
+            if let Some(end) = stripped.find('"') {
+                return Some(stripped[..end].to_string());
             }
-        } else if value_part.starts_with('\'') {
-            if let Some(end) = value_part[1..].find('\'') {
-                return Some(value_part[1..1 + end].to_string());
+        } else if let Some(stripped) = value_part.strip_prefix('\'') {
+            if let Some(end) = stripped.find('\'') {
+                return Some(stripped[..end].to_string());
             }
         } else {
             // Unquoted attribute

--- a/tests/integration/test_cli_direct_fetch.py
+++ b/tests/integration/test_cli_direct_fetch.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+
+import pytest
+
+CLI_PATH = "./cli/target/release/do-wdr"
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.path.exists(CLI_PATH),
+        reason=f"CLI binary not found at {CLI_PATH}.",
+    ),
+]
+
+
+@pytest.mark.integration
+def test_cli_direct_fetch_latex():
+    """Test that direct_fetch correctly extracts LaTeX from img alt tags on Wikipedia."""
+    url = "https://en.wikipedia.org/wiki/Quadratic_formula"
+
+    result = subprocess.run(
+        [CLI_PATH, "resolve", url, "--provider", "direct_fetch"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    content = result.stdout
+    # Wikipedia uses {\displaystyle ...} in alt tags
+    assert "{\\displaystyle" in content
+    assert "ax^{2}+bx+c=0" in content
+
+
+@pytest.mark.integration
+def test_cli_direct_fetch_code_lang():
+    """Test that direct_fetch extracts language hints and handles nested code blocks."""
+    # Using a site known to have <pre class="language-..."> or similar
+    url = "https://react.dev"
+
+    result = subprocess.run(
+        [CLI_PATH, "resolve", url, "--provider", "direct_fetch"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    content = result.stdout
+    # Check for fenced code blocks (we expect ``` without necessarily a lang if it's not in class)
+    # But react.dev usually has them.
+    assert "```" in content
+    # Ensure we don't have the double backtick bug ` ` `
+    assert "` ` `" not in content
+    assert "function" in content


### PR DESCRIPTION
This PR improves the Rust CLI's ability to output "LLM-ready" Markdown from plain HTML via the `direct_fetch` provider.

Key changes:
1.  **LaTeX Support**: Modified `strip_html` in `cli/src/providers/direct_fetch.rs` to extract and include `alt` attribute text from `<img>` tags. This enables the capture of LaTeX math formulas on sites like Wikipedia.
2.  **Language Hints**: Added logic to parse `class` attributes from `<pre>` tags, identifying `language-*` or `lang-*` hints to produce fenced code blocks with proper syntax highlighting markers in Markdown.
3.  **Code Block Refinement**: Fixed a bug where nested `<pre><code>` structures resulted in double-backtick artifacts (e.g., `` ` ``` ``). The parser now correctly detects nesting and ensures clean fenced blocks.
4.  **Integration Testing**: Introduced `tests/integration/test_cli_direct_fetch.py` which specifically validates these improvements against live targets (Wikipedia for LaTeX and React.dev for code blocks).

All tests, including the new integration suite and existing unit tests, passed successfully. The changes were also verified by a full run of the `scripts/quality_gate.sh`.

---
*PR created automatically by Jules for task [6389737794185846745](https://jules.google.com/task/6389737794185846745) started by @d-oit*