### PR TITLE
Sanitize and guard against placeholder metadata in result cards

### DIFF
--- a/web/app/components/ResultCard.tsx
+++ b/web/app/components/ResultCard.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import type { ProviderResult } from "@/lib/results";
 
+const PLACEHOLDER_REGEX = /^(n\/a|na|unknown|none|-|–)$/i;
+
 interface ResultCardProps {
   result: ProviderResult;
   onCopy: (value: string) => Promise<void> | void;
@@ -42,8 +44,12 @@ export default function ResultCard({ result, onCopy, onHelpfulToggle, helpful }:
           <div className="text-[10px] text-text-dim break-all">{result.normalizedUrl}</div>
         )}
         <div className="text-[10px] text-text-dim flex gap-3 flex-wrap">
-          {result.author && <span>By {result.author}</span>}
-          {result.published && <span>{result.published}</span>}
+          {result.author && !PLACEHOLDER_REGEX.test(result.author.trim()) && (
+            <span>By {result.author}</span>
+          )}
+          {result.published && !PLACEHOLDER_REGEX.test(result.published.trim()) && (
+            <span>{result.published}</span>
+          )}
         </div>
       </header>
       <p className="text-[12px] text-foreground whitespace-pre-wrap leading-relaxed">{result.snippet}</p>

--- a/web/lib/results.ts
+++ b/web/lib/results.ts
@@ -10,6 +10,13 @@ export interface ProviderResult {
 }
 
 const SPLIT_REGEX = /\n-{3,}\n+/g;
+const PLACEHOLDER_VALUES = new Set(["n/a", "na", "unknown", "none", "-", "–", ""]);
+
+function sanitizeMeta(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return PLACEHOLDER_VALUES.has(trimmed.toLowerCase()) ? undefined : trimmed || undefined;
+}
 
 function extractFirstUrlCandidate(input: string): string | undefined {
   const fromParen = input.match(/https?:\/\/[^)\s]+/);
@@ -70,11 +77,11 @@ function parseBlock(block: string, index: number): ProviderResult | null {
       continue;
     }
     if (lower.startsWith("author:")) {
-      author = line.split(/author:/i)[1]?.trim();
+      author = sanitizeMeta(line.split(/author:/i)[1]);
       continue;
     }
     if (lower.startsWith("published:")) {
-      published = line.split(/published:/i)[1]?.trim();
+      published = sanitizeMeta(line.split(/published:/i)[1]);
       continue;
     }
     if (lower.startsWith("highlights:")) {

--- a/web/tests/e2e/metadata.spec.ts
+++ b/web/tests/e2e/metadata.spec.ts
@@ -43,36 +43,36 @@ async function waitForApp(page: import("@playwright/test").Page): Promise<void> 
 }
 
 test.describe("Metadata Display", () => {
-  test("hides 'By N/A' and 'N/A' when metadata is missing or placeholder", async ({ page }) => {
+  test("suppresses placeholder metadata independently", async ({ page }) => {
     await page.route("**/api/resolve", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({
           markdown: `
-Title: Result with N/A metadata
-URL: https://example.com/na
-Author: N/A
-Published: N/A
+Title: Result with placeholder author
+URL: https://example.com/1
+Author: unknown
+Published: 2023-05-01
 
 Highlights:
-This result should have hidden metadata line.
+Author should be suppressed, but date should show.
 ---
-Title: Result with empty metadata
-URL: https://example.com/empty
-Author:
-Published:
-
-Highlights:
-This result should also have hidden metadata line.
----
-Title: Result with valid metadata
-URL: https://example.com/valid
+Title: Result with placeholder date
+URL: https://example.com/2
 Author: Jane Doe
-Published: 2023-01-01
+Published: -
 
 Highlights:
-This result should show metadata.
+Date should be suppressed, but author should show.
+---
+Title: Result with all placeholders
+URL: https://example.com/3
+Author: NA
+Published: –
+
+Highlights:
+Both should be suppressed.
 `,
         }),
       })
@@ -83,27 +83,24 @@ This result should show metadata.
     await input.fill("test query");
     await page.getByRole("button", { name: "Fetch" }).click();
 
-    // Check first result (N/A)
-    const result1 = page.locator('article').filter({ hasText: 'Result with N/A metadata' });
+    // 4. ResultCard component suppresses author section when the value is a placeholder
+    const result1 = page.locator('article').filter({ hasText: 'Result with placeholder author' });
     await expect(result1).toBeVisible();
-    // The metadata div should be empty (or not have the spans)
-    const meta1 = result1.locator('header > div.flex.gap-3');
-    await expect(meta1.locator('span')).toHaveCount(0);
+    await expect(result1.locator('text=By')).not.toBeVisible();
+    await expect(result1.locator('text=2023-05-01')).toBeVisible();
 
-    // Check second result (empty)
-    const result2 = page.locator('article').filter({ hasText: 'Result with empty metadata' });
+    // 5. ResultCard component suppresses publication date when the value is a placeholder
+    const result2 = page.locator('article').filter({ hasText: 'Result with placeholder date' });
     await expect(result2).toBeVisible();
-    const meta2 = result2.locator('header > div.flex.gap-3');
-    await expect(meta2.locator('span')).toHaveCount(0);
+    await expect(result2.locator('text=By Jane Doe')).toBeVisible();
+    await expect(result2.locator('text=-')).not.toBeVisible();
 
-    // Check third result (valid)
-    const result3 = page.locator('article').filter({ hasText: 'Result with valid metadata' });
+    const result3 = page.locator('article').filter({ hasText: 'Result with all placeholders' });
     await expect(result3).toBeVisible();
-    const meta3 = result3.locator('header > div.flex.gap-3');
-    await expect(meta3.locator('span')).toHaveCount(2);
-    await expect(meta3.locator('text=By Jane Doe')).toBeVisible();
-    await expect(meta3.locator('text=2023-01-01')).toBeVisible();
+    await expect(result3.locator('text=By')).not.toBeVisible();
+    await expect(result3.locator('text=–')).not.toBeVisible();
 
-    await page.screenshot({ path: 'metadata-fix-verification.png' });
+    // Check that the metadata container itself has no visible spans
+    await expect(result3.locator('header > div.flex.gap-3 span')).toHaveCount(0);
   });
 });

--- a/web/tests/e2e/metadata.spec.ts
+++ b/web/tests/e2e/metadata.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from "@playwright/test";
+
+async function mockAppState(page: import("@playwright/test").Page): Promise<void> {
+  await page.route("**/api/key-status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ exa: false, serper: false, tavily: false, firecrawl: false, mistral: false }),
+    });
+  });
+
+  await page.route("**/api/ui-state", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          sidebarCollapsed: false,
+          showApiKeys: false,
+          showAdvanced: false,
+          activeProfile: "free",
+          selectedProviders: [],
+          maxChars: 8000,
+          skipCache: false,
+          deepResearch: false,
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+}
+
+async function waitForApp(page: import("@playwright/test").Page): Promise<void> {
+  await mockAppState(page);
+  await page.goto("/");
+  await expect(page.getByTestId("app-loaded")).toBeVisible({ timeout: 10000 });
+}
+
+test.describe("Metadata Display", () => {
+  test("hides 'By N/A' and 'N/A' when metadata is missing or placeholder", async ({ page }) => {
+    await page.route("**/api/resolve", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          markdown: `
+Title: Result with N/A metadata
+URL: https://example.com/na
+Author: N/A
+Published: N/A
+
+Highlights:
+This result should have hidden metadata line.
+---
+Title: Result with empty metadata
+URL: https://example.com/empty
+Author:
+Published:
+
+Highlights:
+This result should also have hidden metadata line.
+---
+Title: Result with valid metadata
+URL: https://example.com/valid
+Author: Jane Doe
+Published: 2023-01-01
+
+Highlights:
+This result should show metadata.
+`,
+        }),
+      })
+    );
+
+    await waitForApp(page);
+    const input = page.locator("input[type='text']");
+    await input.fill("test query");
+    await page.getByRole("button", { name: "Fetch" }).click();
+
+    // Check first result (N/A)
+    const result1 = page.locator('article').filter({ hasText: 'Result with N/A metadata' });
+    await expect(result1).toBeVisible();
+    // The metadata div should be empty (or not have the spans)
+    const meta1 = result1.locator('header > div.flex.gap-3');
+    await expect(meta1.locator('span')).toHaveCount(0);
+
+    // Check second result (empty)
+    const result2 = page.locator('article').filter({ hasText: 'Result with empty metadata' });
+    await expect(result2).toBeVisible();
+    const meta2 = result2.locator('header > div.flex.gap-3');
+    await expect(meta2.locator('span')).toHaveCount(0);
+
+    // Check third result (valid)
+    const result3 = page.locator('article').filter({ hasText: 'Result with valid metadata' });
+    await expect(result3).toBeVisible();
+    const meta3 = result3.locator('header > div.flex.gap-3');
+    await expect(meta3.locator('span')).toHaveCount(2);
+    await expect(meta3.locator('text=By Jane Doe')).toBeVisible();
+    await expect(meta3.locator('text=2023-01-01')).toBeVisible();
+
+    await page.screenshot({ path: 'metadata-fix-verification.png' });
+  });
+});

--- a/web/tests/results.test.ts
+++ b/web/tests/results.test.ts
@@ -3,7 +3,10 @@ import { parseProviderResults } from "../lib/results";
 
 describe("parseProviderResults with metadata", () => {
   it("should return undefined for various placeholder authors", () => {
-    const placeholders = ["N/A", "na", "unknown", "none", "-", "–", "", "  "];
+    // 1. Parser correctly identifies and normalizes 'N/A' (case-insensitive) to undefined
+    // 2. Parser correctly normalizes dash placeholders ('-', '–') to undefined
+    // 3. Parser treats whitespace-only metadata strings as undefined
+    const placeholders = ["N/A", "n/a", "na", "NA", "unknown", "none", "-", "–", "", "  ", "\t\n"];
     placeholders.forEach((placeholder) => {
       const markdown = `
 Title: Test Result
@@ -20,7 +23,7 @@ Test snippet
   });
 
   it("should return undefined for various placeholder published dates", () => {
-    const placeholders = ["N/A", "na", "unknown", "none", "-", "–", "", "  "];
+    const placeholders = ["N/A", "n/a", "na", "NA", "unknown", "none", "-", "–", "", "  ", "\t\n"];
     placeholders.forEach((placeholder) => {
       const markdown = `
 Title: Test Result

--- a/web/tests/results.test.ts
+++ b/web/tests/results.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { parseProviderResults } from "../lib/results";
+
+describe("parseProviderResults with metadata", () => {
+  it("should return undefined for various placeholder authors", () => {
+    const placeholders = ["N/A", "na", "unknown", "none", "-", "–", "", "  "];
+    placeholders.forEach((placeholder) => {
+      const markdown = `
+Title: Test Result
+URL: https://example.com
+Author: ${placeholder}
+Published: 2023-01-01
+
+Highlights:
+Test snippet
+`;
+      const results = parseProviderResults(markdown);
+      expect(results[0].author, `Failed for placeholder: "${placeholder}"`).toBeUndefined();
+    });
+  });
+
+  it("should return undefined for various placeholder published dates", () => {
+    const placeholders = ["N/A", "na", "unknown", "none", "-", "–", "", "  "];
+    placeholders.forEach((placeholder) => {
+      const markdown = `
+Title: Test Result
+URL: https://example.com
+Author: John Doe
+Published: ${placeholder}
+
+Highlights:
+Test snippet
+`;
+      const results = parseProviderResults(markdown);
+      expect(results[0].published, `Failed for placeholder: "${placeholder}"`).toBeUndefined();
+    });
+  });
+
+  it("should return valid author and published date", () => {
+    const markdown = `
+Title: Test Result
+URL: https://example.com
+Author: John Doe
+Published: 2023-01-01
+
+Highlights:
+Test snippet
+`;
+    const results = parseProviderResults(markdown);
+    expect(results[0].author).toBe("John Doe");
+    expect(results[0].published).toBe("2023-01-01");
+  });
+});

--- a/web/tests/results.test.ts
+++ b/web/tests/results.test.ts
@@ -15,7 +15,7 @@ Highlights:
 Test snippet
 `;
       const results = parseProviderResults(markdown);
-      expect(results[0].author, `Failed for placeholder: "${placeholder}"`).toBeUndefined();
+      expect(results[0]?.author, `Failed for placeholder: "${placeholder}"`).toBeUndefined();
     });
   });
 
@@ -32,7 +32,7 @@ Highlights:
 Test snippet
 `;
       const results = parseProviderResults(markdown);
-      expect(results[0].published, `Failed for placeholder: "${placeholder}"`).toBeUndefined();
+      expect(results[0]?.published, `Failed for placeholder: "${placeholder}"`).toBeUndefined();
     });
   });
 
@@ -47,7 +47,7 @@ Highlights:
 Test snippet
 `;
     const results = parseProviderResults(markdown);
-    expect(results[0].author).toBe("John Doe");
-    expect(results[0].published).toBe("2023-01-01");
+    expect(results[0]?.author).toBe("John Doe");
+    expect(results[0]?.published).toBe("2023-01-01");
   });
 });


### PR DESCRIPTION
This PR addresses a bug where result cards in the Web UI displayed placeholder text like "By N/A" or "N/A" for author and publication date metadata.

The fix is implemented at two levels:
1. **Parser level (`web/lib/results.ts`)**: A new `sanitizeMeta` function identifies common placeholder strings (n/a, na, unknown, none, -, –) and normalizes them to `undefined`. This ensures that the `ProviderResult` objects contain clean data.
2. **Component level (`web/app/components/ResultCard.tsx`)**: A defensive guard using a case-insensitive regex check is added to the rendering logic. This prevents any remaining or future placeholder values from being displayed in the UI.

New unit tests and an E2E Playwright test have been added to ensure the fix works as expected across different scenarios and to prevent regressions.

Fixes #386

---
*PR created automatically by Jules for task [15638711924007084794](https://jules.google.com/task/15638711924007084794) started by @d-oit*