### PR TITLE
feat(ux): improve search and configuration accessibility

### DIFF
--- a/web/app/components/MainContent.tsx
+++ b/web/app/components/MainContent.tsx
@@ -130,6 +130,7 @@ export default function MainContent({
                   setQualityScore(null);
                   setParsedResults([]);
                   setViewRaw(false);
+                  inputRef.current?.focus();
                 }}
                 aria-label="Clear input and results"
                 className="bg-transparent text-text-dim px-4 py-2 text-[13px] border-2 border-border-muted hover:border-accent hover:text-accent min-h-[44px]"
@@ -145,7 +146,11 @@ export default function MainContent({
           </div>
         )}
         {providerStatus && (
-          <div className="text-[11px] text-accent mt-2 animate-pulse">
+          <div
+            role="status"
+            aria-live="polite"
+            className="text-[11px] text-accent mt-2 animate-pulse"
+          >
             {providerStatus}
           </div>
         )}

--- a/web/app/components/Sidebar.tsx
+++ b/web/app/components/Sidebar.tsx
@@ -199,12 +199,14 @@ export default function Sidebar({
             <button
               data-testid="api-keys-toggle"
               onClick={() => setApiKeysOpen(!apiKeysOpen)}
+              aria-expanded={apiKeysOpen}
+              aria-controls="api-keys-panel"
               className="text-[11px] text-text-muted hover:text-foreground text-left min-h-[44px] py-2"
             >
               {apiKeysOpen ? "▼" : "▶"} API Keys
             </button>
             {apiKeysOpen && (
-              <div className="flex flex-col gap-3 pl-2">
+              <div id="api-keys-panel" className="flex flex-col gap-3 pl-2">
                 <div className="flex flex-col gap-1">
                   <div className="flex items-center justify-between">
                     <label className="text-[11px] text-text-muted">Max chars</label>


### PR DESCRIPTION
This change implements several micro-UX and accessibility improvements to the web interface:

1. Search input focus management: Clicking the 'Clear' button now explicitly returns focus to the search input, facilitating rapid re-entry.
2. Screen reader status updates: The provider status display now uses 'role="status"' and 'aria-live="polite"', ensuring status changes like 'Fetching...' are announced by assistive technologies.
3. Disclosure pattern for API keys: Added 'aria-expanded' and 'aria-controls' to the API keys toggle in the sidebar to correctly describe the collapsible section to screen readers.

Verified with Playwright and visual inspection of screenshots.

---
*PR created automatically by Jules for task [701765183051595170](https://jules.google.com/task/701765183051595170) started by @d-oit*