### PR TITLE
Strengthen bridge and improve LLM-ready Markdown output

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -30,6 +30,7 @@ fn init_logging(verbose: u8) {
         .with_thread_ids(true)
         .with_file(true)
         .with_line_number(true)
+        .with_writer(std::io::stderr)
         .init();
 }
 

--- a/cli/src/providers/direct_fetch.rs
+++ b/cli/src/providers/direct_fetch.rs
@@ -102,6 +102,15 @@ fn decode_entities(text: &str) -> String {
         .replace("&#x27;", "'")
         .replace("&#39;", "'")
         .replace("&nbsp;", " ")
+        .replace("&copy;", "©")
+        .replace("&reg;", "®")
+        .replace("&trade;", "™")
+        .replace("&ndash;", "–")
+        .replace("&mdash;", "—")
+        .replace("&lsquo;", "‘")
+        .replace("&rsquo;", "’")
+        .replace("&ldquo;", "“")
+        .replace("&rdquo;", "”")
         .replace("&#8288;", "") // word joiner
         .replace("&amp;", "&") // Ampersand last to avoid double-unescaping
         .replace("\u{2060}", "") // Remove word joiner
@@ -157,8 +166,27 @@ fn strip_html(html: &str) -> String {
     let mut in_pre = false;
 
     let block_tags: HashSet<&str> = [
-        "p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "tr", "pre", "br", "article",
-        "section", "header", "footer", "nav", "aside",
+        "p",
+        "div",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "li",
+        "tr",
+        "pre",
+        "br",
+        "article",
+        "section",
+        "header",
+        "footer",
+        "nav",
+        "aside",
+        "main",
+        "figure",
+        "figcaption",
     ]
     .iter()
     .cloned()
@@ -306,5 +334,12 @@ mod tests {
         let html = "<img src=\"math.svg\" alt=\"x^2 + y^2 = z^2\">";
         let result = strip_html(html);
         assert!(result.contains("x^2 + y^2 = z^2"));
+    }
+
+    #[test]
+    fn test_extended_entities() {
+        let html = "<p>Copyright &copy; 2026 &mdash; All rights &reg; reserved &trade;.</p>";
+        let result = strip_html(html);
+        assert!(result.contains("Copyright © 2026 — All rights ® reserved ™."));
     }
 }

--- a/tests/integration/test_cli_markdown.py
+++ b/tests/integration/test_cli_markdown.py
@@ -14,6 +14,12 @@ pytestmark = [
 ]
 
 
+def check(condition, message="Assertion failed"):
+    """Security-compliant assertion helper that won't be removed by optimization."""
+    if not condition:
+        raise AssertionError(message)
+
+
 @pytest.mark.integration
 def test_cli_output_markdown_code_blocks():
     """Test that the CLI correctly outputs Markdown with code blocks from a documentation site."""
@@ -27,12 +33,12 @@ def test_cli_output_markdown_code_blocks():
     )
 
     content = result.stdout
-    assert len(content) > 500
+    check(len(content) > 500, "Content too short")
     # Check for presence of code blocks
-    assert "```" in content
+    check("```" in content, "Missing code blocks")
     # Ensure no common 'unparsed' indicators
-    assert "<pre" not in content
-    assert "<code>" not in content
+    check("<pre" not in content, "Found unparsed <pre> tag")
+    check("<code>" not in content, "Found unparsed <code> tag")
 
 
 @pytest.mark.integration
@@ -48,7 +54,7 @@ def test_cli_output_markdown_latex():
     )
 
     content = result.stdout
-    assert len(content) > 500
+    check(len(content) > 500, "Content too short")
 
     # Check for LaTeX patterns
     # Wikipedia Jina output often uses $ or \( \) or images with alt text
@@ -56,7 +62,7 @@ def test_cli_output_markdown_latex():
     latex_indicators = ["\\pm", "\\sqrt", "b^2", "2a", "$"]
     found = any(ind in content for ind in latex_indicators)
 
-    assert found, f"No LaTeX indicators found in output: {content[:500]}..."
+    check(found, f"No LaTeX indicators found in output: {content[:500]}...")
 
 
 @pytest.mark.integration
@@ -73,10 +79,13 @@ def test_cli_javascript_heavy_site():
     )
 
     content = result.stdout
-    assert len(content) > 500
+    check(len(content) > 500, "Content too short")
     # Should have meaningful content, not just a 'loading' or 'enable JS' message
-    assert "React" in content
-    assert "Components" in content or "Hooks" in content or "Learn" in content
+    check("React" in content, "Missing 'React' keyword")
+    check(
+        "Components" in content or "Hooks" in content or "Learn" in content,
+        "Missing React learning keywords",
+    )
 
 
 @pytest.mark.integration
@@ -96,17 +105,17 @@ def test_cli_llm_ready_markdown():
     content = result.stdout
 
     # Check for YAML frontmatter
-    assert content.startswith("---")
-    assert "relevance_score:" in content
-    assert "intent_category:" in content
-    assert "token_estimate:" in content
-    assert "last_updated:" in content
+    check(content.startswith("---"), "Missing YAML frontmatter start")
+    check("relevance_score:" in content, "Missing relevance_score in frontmatter")
+    check("intent_category:" in content, "Missing intent_category in frontmatter")
+    check("token_estimate:" in content, "Missing token_estimate in frontmatter")
+    check("last_updated:" in content, "Missing last_updated in frontmatter")
 
     # Check for Structural Anchors
-    assert "[ANCHOR: SUMMARY]" in content
-    assert "[ANCHOR: TECHNICAL_DETAILS]" in content
-    assert "[ANCHOR: CITATIONS]" in content
+    check("[ANCHOR: SUMMARY]" in content, "Missing [ANCHOR: SUMMARY]")
+    check("[ANCHOR: TECHNICAL_DETAILS]" in content, "Missing [ANCHOR: TECHNICAL_DETAILS]")
+    check("[ANCHOR: CITATIONS]" in content, "Missing [ANCHOR: CITATIONS]")
 
     # Ensure citations are present at the end
-    assert "[1]" in content
-    assert url in content
+    check("[1]" in content, "Missing citation marker [1]")
+    check(url in content, f"Missing source URL {url}")

--- a/tests/integration/test_cli_markdown.py
+++ b/tests/integration/test_cli_markdown.py
@@ -20,7 +20,10 @@ def test_cli_output_markdown_code_blocks():
     url = "https://docs.rs/tokio/latest/tokio/"
 
     result = subprocess.run(
-        [CLI_PATH, "resolve", url, "--provider", "jina"], capture_output=True, text=True, check=True
+        [CLI_PATH, "resolve", url, "--provider", "jina"],
+        capture_output=True,
+        text=True,
+        check=True,
     )
 
     content = result.stdout
@@ -38,7 +41,10 @@ def test_cli_output_markdown_latex():
     url = "https://en.wikipedia.org/wiki/Quadratic_formula"
 
     result = subprocess.run(
-        [CLI_PATH, "resolve", url, "--provider", "jina"], capture_output=True, text=True, check=True
+        [CLI_PATH, "resolve", url, "--provider", "jina"],
+        capture_output=True,
+        text=True,
+        check=True,
     )
 
     content = result.stdout
@@ -60,7 +66,10 @@ def test_cli_javascript_heavy_site():
     url = "https://react.dev/learn"
 
     result = subprocess.run(
-        [CLI_PATH, "resolve", url, "--provider", "jina"], capture_output=True, text=True, check=True
+        [CLI_PATH, "resolve", url, "--provider", "jina"],
+        capture_output=True,
+        text=True,
+        check=True,
     )
 
     content = result.stdout
@@ -68,3 +77,36 @@ def test_cli_javascript_heavy_site():
     # Should have meaningful content, not just a 'loading' or 'enable JS' message
     assert "React" in content
     assert "Components" in content or "Hooks" in content or "Learn" in content
+
+
+@pytest.mark.integration
+def test_cli_llm_ready_markdown():
+    """Test that the CLI output follows 2026 LLM-ready standards."""
+    url = "https://docs.rs/tokio/latest/tokio/"
+
+    # Enable synthesis to see LLM-ready output (frontmatter + anchors)
+    result = subprocess.run(
+        [CLI_PATH, "resolve", url, "--provider", "jina", "--synthesize"],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={**os.environ, "MISTRAL_API_KEY": "test_key"},
+    )
+
+    content = result.stdout
+
+    # Check for YAML frontmatter
+    assert content.startswith("---")
+    assert "relevance_score:" in content
+    assert "intent_category:" in content
+    assert "token_estimate:" in content
+    assert "last_updated:" in content
+
+    # Check for Structural Anchors
+    assert "[ANCHOR: SUMMARY]" in content
+    assert "[ANCHOR: TECHNICAL_DETAILS]" in content
+    assert "[ANCHOR: CITATIONS]" in content
+
+    # Ensure citations are present at the end
+    assert "[1]" in content
+    assert url in content


### PR DESCRIPTION
This PR strengthens the bridge between the Python frontend and Rust CLI by improving the quality of the generated Markdown and ensuring compliance with the 2026 LLM-ready standards. Key improvements include better HTML entity handling, more robust block element detection, and a new integration test suite specifically for LLM-ready output verification. Additionally, CLI logging has been moved to stderr to prevent interference with programmatic stdout consumption.

---
*PR created automatically by Jules for task [2223690292285664758](https://jules.google.com/task/2223690292285664758) started by @d-oit*