### PR TITLE
feat(ux): add clear-text button to search input

### DIFF
--- a/web/app/components/MainContent.tsx
+++ b/web/app/components/MainContent.tsx
@@ -97,18 +97,33 @@ export default function MainContent({
           <label htmlFor="search-input" className="sr-only">
             URL or search query
           </label>
-          <input
-            id="search-input"
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
-            placeholder="URL or search query..."
-            aria-invalid={!!error}
-            aria-errormessage={error ? "search-error" : undefined}
-            className="flex-1 bg-transparent text-[20px] sm:text-[24px] text-foreground placeholder:text-text-dim tracking-tight"
-          />
+          <div className="flex-1 relative">
+            <input
+              id="search-input"
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSubmit()}
+              placeholder="URL or search query..."
+              aria-invalid={!!error}
+              aria-errormessage={error ? "search-error" : undefined}
+              className="w-full bg-transparent text-[20px] sm:text-[24px] text-foreground placeholder:text-text-dim tracking-tight pr-10"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => {
+                  setQuery("");
+                  inputRef.current?.focus();
+                }}
+                className="absolute right-0 top-1/2 -translate-y-1/2 p-2 text-text-dim hover:text-accent transition-colors"
+                aria-label="Clear query"
+              >
+                ×
+              </button>
+            )}
+          </div>
           {query.trim() && (
             <div className="flex items-center gap-2">
               <button

--- a/web/tests/e2e/app.spec.ts
+++ b/web/tests/e2e/app.spec.ts
@@ -361,14 +361,21 @@ test.describe("Keyboard Navigation", () => {
     await expect(input).toBeFocused();
   });
 
-  test("button is focusable when visible", async ({ page }) => {
+  test("buttons are focusable when visible", async ({ page }) => {
     await page.goto("/");
-    const input = page.locator("input[type='text']");
+    const input = page.locator("input[placeholder*='URL']");
     await input.fill("some query");
     await input.focus();
+
+    // Tab 1: Clear query button
     await page.keyboard.press("Tab");
-    const button = page.getByRole("button", { name: "Fetch" });
-    await expect(button).toBeFocused();
+    const clearButton = page.getByRole("button", { name: "Clear query" });
+    await expect(clearButton).toBeFocused();
+
+    // Tab 2: Fetch button
+    await page.keyboard.press("Tab");
+    const fetchButton = page.getByRole("button", { name: "Fetch" });
+    await expect(fetchButton).toBeFocused();
   });
 
   test("input accepts keyboard input", async ({ page }) => {


### PR DESCRIPTION
This PR implements a micro-UX improvement by adding a clear-text button to the main search input.

Key changes:
- Wrapped the search input in a `relative` container in `web/app/components/MainContent.tsx`.
- Added a `button` with the `×` character, absolutely positioned to the right.
- Added `pr-10` to the search input to prevent text overlap.
- The button clears the query state and restores focus to the input.
- Included accessibility features: `type="button"`, `aria-label="Clear query"`, and focus management.
- Verified functionality with Playwright (screenshots and video generated).
- Ensured consistency with the history search input's existing clear functionality.

---
*PR created automatically by Jules for task [17550766765863710645](https://jules.google.com/task/17550766765863710645) started by @d-oit*