### PR TITLE
Implement .cleanup-ignore support in cleanup.yml workflow

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -68,9 +68,34 @@ jobs:
             markdown_list=""
             raw_list=""
 
+            # Load .cleanup-ignore entries
+            ignored_files=()
+            skipped_count=0
+            if [ -f ".cleanup-ignore" ]; then
+              while IFS= read -r line || [[ -n "$line" ]]; do
+                # Skip comments and empty lines
+                [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+                ignored_files+=("$line")
+              done < ".cleanup-ignore"
+            fi
+
             for script in scripts/*.sh; do
               if [ -f "${script}" ]; then
                 script_name=$(basename "${script}")
+
+                # Check if the file is in .cleanup-ignore
+                skip=false
+                for ignored in "${ignored_files[@]}"; do
+                  if [ "${script}" = "${ignored}" ] || [ "${script_name}" = "${ignored}" ]; then
+                    skip=true
+                    break
+                  fi
+                done
+                if [ "$skip" = true ]; then
+                  ((skipped_count++))
+                  continue
+                fi
+
                 refs=$(grep -r "${script_name}" . \
                   --include="*.yml" --include="*.yaml" \
                   --include="*.sh" --include="*.md" \
@@ -104,6 +129,12 @@ jobs:
               echo ""
               echo "## Temp/Debug Files"
               echo "${old_files}"
+            fi
+
+            if [ "${skipped_count}" -gt 0 ]; then
+              echo ""
+              echo "## Ignored Files"
+              echo "Skipped ${skipped_count} files based on .cleanup-ignore"
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
 


### PR DESCRIPTION
This change implements full support for the `.cleanup-ignore` file within the `.github/workflows/cleanup.yml` workflow. 

Previously, the workflow only had hardcoded exceptions and ignored the `.cleanup-ignore` file mentioned in its PR body template. The updated logic:
1. Reads `.cleanup-ignore` at the start of the detection step.
2. Gracefully handles comments (`#`) and empty lines.
3. Excludes any script if its basename or relative path matches an entry in the ignore file.
4. Tracks and reports the number of skipped files in the GitHub Action step summary.

This fix ensures that scripts like `scripts/pre-commit-hook.sh` (which are currently listed in `.cleanup-ignore`) are no longer incorrectly flagged for deletion.

Fixes #424

---
*PR created automatically by Jules for task [12929004119878635715](https://jules.google.com/task/12929004119878635715) started by @d-oit*