### PR TITLE
Add Content Security Policy and Security Headers

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -11,6 +11,30 @@ const nextConfig = {
   },
   reactStrictMode: true,
   poweredByHeader: false,
+  headers: async () => [
+    {
+      source: "/:path*",
+      headers: [
+        {
+          key: "Content-Security-Policy",
+          value:
+            "default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; font-src 'self' data:; connect-src 'self' https://vitals.vercel-insights.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;",
+        },
+        {
+          key: "X-Content-Type-Options",
+          value: "nosniff",
+        },
+        {
+          key: "X-Frame-Options",
+          value: "DENY",
+        },
+        {
+          key: "Referrer-Policy",
+          value: "strict-origin-when-cross-origin",
+        },
+      ],
+    },
+  ],
 };
 
 export default nextConfig;


### PR DESCRIPTION
Added industry-standard security headers to the Next.js application via `web/next.config.mjs`:
- `Content-Security-Policy`: Restricts resource loading to trusted origins, mitigating XSS and injection attacks.
- `X-Content-Type-Options: nosniff`: Prevents MIME-type sniffing.
- `X-Frame-Options: DENY`: Mitigates clickjacking by preventing the site from being embedded in frames.
- `Referrer-Policy: strict-origin-when-cross-origin`: Protects sensitive information in referrer headers.

Verification:
- Unit tests in `web/` passed.
- Playwright E2E tests passed (74 tests).
- Linting clean.
- Code review feedback addressed (reverted auto-generated config changes).

---
*PR created automatically by Jules for task [10393771477913996822](https://jules.google.com/task/10393771477913996822) started by @d-oit*