### PR TITLE
feat(ux): enhance result card accessibility and interactive feedback consistency

### DIFF
--- a/web/app/components/MetadataBar.tsx
+++ b/web/app/components/MetadataBar.tsx
@@ -71,7 +71,8 @@ export function MetadataBar({
           onClick={handleCopyResult}
           aria-label={copied ? "Copied to clipboard" : "Copy to clipboard"}
           aria-live="polite"
-          className="hover:text-foreground transition-colors min-h-[36px] px-2"
+          title="Copy full result as markdown"
+          className={`transition-colors min-h-[36px] px-2 ${copied ? "text-accent" : "text-text-muted hover:text-foreground"}`}
         >
           {copied ? "Copied" : "Copy"}
         </button>

--- a/web/app/components/ResultCard.tsx
+++ b/web/app/components/ResultCard.tsx
@@ -14,21 +14,23 @@ interface ResultCardProps {
 
 const ResultHeader = ({ id, title, url, normalizedUrl }: { id: string; title: string; url?: string | null; normalizedUrl?: string | null }) => (
   <header className="flex flex-col gap-1">
-    {url ? (
-      <a
-        id={id}
-        href={url}
-        target="_blank"
-        rel="noreferrer"
-        className="text-accent text-[15px] hover:underline"
-      >
-        {title}
-      </a>
-    ) : (
-      <h3 id={id} className="text-[15px] text-foreground">
-        {title}
-      </h3>
-    )}
+    <h3 className="text-[15px]">
+      {url ? (
+        <a
+          id={id}
+          href={url}
+          target="_blank"
+          rel="noreferrer"
+          className="text-accent hover:underline"
+        >
+          {title}
+        </a>
+      ) : (
+        <span id={id} className="text-foreground">
+          {title}
+        </span>
+      )}
+    </h3>
     {normalizedUrl && (
       <div className="text-[10px] text-text-dim break-all">{normalizedUrl}</div>
     )}
@@ -76,8 +78,11 @@ export default function ResultCard({ result, onCopy, onHelpfulToggle, helpful }:
       <footer className="flex flex-wrap gap-2 text-[11px]">
         <button
           onClick={handleCopy}
-          className="px-3 py-2 border-2 border-border-muted hover:border-accent text-text-muted"
+          className={`px-3 py-2 border-2 transition-colors ${
+            copying ? "border-accent text-accent" : "border-border-muted text-text-muted hover:border-accent"
+          }`}
           aria-live="polite"
+          title="Copy full result as markdown"
         >
           {copying ? "Copied" : "Copy markdown"}
         </button>

--- a/web/app/components/SearchSection.tsx
+++ b/web/app/components/SearchSection.tsx
@@ -46,6 +46,7 @@ const SearchActions = ({
       <button
         onClick={onClear}
         aria-label="Clear input and results"
+        title="Clear input and results"
         className="bg-transparent text-text-dim px-4 py-2 text-[13px] border-2 border-border-muted hover:border-accent hover:text-accent min-h-[44px]"
       >
         Clear
@@ -130,6 +131,7 @@ export function SearchSection({
               onClick={handleClearQuery}
               className="absolute right-0 top-1/2 -translate-y-1/2 p-2 text-text-dim hover:text-accent transition-colors"
               aria-label="Clear query"
+              title="Clear query"
             >
               ×
             </button>


### PR DESCRIPTION
This PR implements a set of micro-UX and accessibility improvements to the web interface.

Key changes:
1.  **Accessibility**: Result titles in `ResultCard` are now wrapped in `<h3>` tags, providing a consistent and semantic heading hierarchy for screen readers.
2.  **Visual Feedback**: The "Copy" buttons in both `ResultCard` and `MetadataBar` now transition to the `accent` color when a copy is successful, giving users immediate visual confirmation of the transient "Copied" state.
3.  **Discoverability**: Added `title` attributes to the "Clear" and "Copy" buttons to provide more context for mouse users, complementing the existing `aria-labels`.

These changes were verified visually and through the repository's linting and test suite.

---
*PR created automatically by Jules for task [17396976809289246902](https://jules.google.com/task/17396976809289246902) started by @d-oit*