### PR TITLE
feat(web): improve ProfileCombobox keyboard accessibility and focus management

### DIFF
--- a/web/app/components/ProfileCombobox.tsx
+++ b/web/app/components/ProfileCombobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, KeyboardEvent } from "react";
 
 interface Option {
   id: string;
@@ -16,7 +16,10 @@ interface ProfileComboboxProps {
 
 export default function ProfileCombobox({ value, onChange, options }: ProfileComboboxProps) {
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
 
   const selectedOption = options.find((o) => o.id === value);
 
@@ -30,36 +33,115 @@ export default function ProfileCombobox({ value, onChange, options }: ProfileCom
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    if (open) {
+      const selectedIndex = options.findIndex((o) => o.id === value);
+      setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+    }
+  }, [open, options, value]);
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const handleSelect = (id: string) => {
+    onChange(id);
+    handleClose();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!open) {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handleOpen();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        handleClose();
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((prev) => (prev + 1) % options.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((prev) => (prev - 1 + options.length) % options.length);
+        break;
+      case "Home":
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case "End":
+        e.preventDefault();
+        setActiveIndex(options.length - 1);
+        break;
+      case "Enter":
+      case " ": {
+        e.preventDefault();
+        const option = options[activeIndex];
+        if (activeIndex >= 0 && option) {
+          handleSelect(option.id);
+        }
+        break;
+      }
+      case "Tab":
+        setOpen(false);
+        break;
+    }
+  };
+
+  // Focus the active option button when activeIndex changes and list is open
+  useEffect(() => {
+    if (open && activeIndex >= 0 && listboxRef.current) {
+      const buttons = listboxRef.current.querySelectorAll("button");
+      (buttons[activeIndex] as HTMLElement)?.focus();
+    }
+  }, [activeIndex, open]);
+
   return (
     <div className="relative" ref={containerRef}>
       <button
-        onClick={() => setOpen(!open)}
+        ref={triggerRef}
+        onClick={() => (open ? handleClose() : handleOpen())}
+        onKeyDown={handleKeyDown}
         className="w-full bg-[#141414] border-2 border-border-muted px-3 py-2 text-left flex items-center justify-between text-[12px] min-h-[44px] hover:border-border-strong focus:border-accent"
         aria-haspopup="listbox"
         aria-expanded={open}
         aria-label="Change search profile"
+        title="Change search profile"
       >
         <span>{selectedOption?.label || "Select profile..."}</span>
-        <span className="text-[10px] text-text-dim">{open ? "▲" : "▼"}</span>
+        <span className="text-[10px] text-text-dim" aria-hidden="true">{open ? "▲" : "▼"}</span>
       </button>
 
       {open && (
         <div
+          ref={listboxRef}
           className="absolute z-10 w-full mt-1 bg-[#141414] border-2 border-border-muted shadow-xl"
           role="listbox"
+          aria-activedescendant={activeIndex >= 0 && options[activeIndex] ? `option-${options[activeIndex].id}` : undefined}
         >
-          {options.map((option) => (
+          {options.map((option, index) => (
             <button
               key={option.id}
-              onClick={() => {
-                onChange(option.id);
-                setOpen(false);
-              }}
-              className={`w-full px-3 py-2 text-left hover:bg-accent hover:text-background transition-colors flex flex-col ${
+              id={`option-${option.id}`}
+              onClick={() => handleSelect(option.id)}
+              onKeyDown={handleKeyDown}
+              className={`w-full px-3 py-2 text-left hover:bg-accent hover:text-background transition-colors flex flex-col focus:outline-none focus:bg-accent focus:text-background ${
                 option.id === value ? "bg-[#222] text-accent" : "text-foreground"
-              }`}
+              } ${index === activeIndex ? "ring-inset ring-2 ring-accent" : ""}`}
               role="option"
               aria-selected={option.id === value}
+              tabIndex={-1}
             >
               <span className="text-[12px] font-bold">{option.label}</span>
               {option.description && <div className="text-[10px] text-text-muted">{option.description}</div>}


### PR DESCRIPTION
Improved the keyboard accessibility and focus management of the `ProfileCombobox` component in the web UI. Users can now navigate options using arrow keys, select with Enter or Space, and close with Escape. Focus is correctly restored to the trigger button when the dropdown closes. ARIA attributes were added to ensure compatibility with screen readers.

---
*PR created automatically by Jules for task [9057120024601639263](https://jules.google.com/task/9057120024601639263) started by @d-oit*