### PR TITLE
feat(resolver): wire visual_clip provider into URL resolution cascade

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2035,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/scripts/_url_resolve.py
+++ b/scripts/_url_resolve.py
@@ -15,6 +15,7 @@ from scripts.providers_impl import (
     resolve_with_jina,
     resolve_with_mistral_browser,
     resolve_with_ocr,
+    resolve_with_visual_clip,
 )
 from scripts.semantic_cache import get_semantic_cache
 from scripts.state import circuit_breakers as _circuit_breakers
@@ -74,16 +75,26 @@ __all__ = [
 
 
 def resolve_url(
-    url: str, max_chars: int = 8000, profile: Profile = Profile.BALANCED
+    url: str,
+    max_chars: int = 8000,
+    profile: Profile = Profile.BALANCED,
+    query: str | None = None,
+    skip_providers: set[str] | None = None,
 ) -> dict[str, Any]:
-    for result in resolve_url_stream(url, max_chars, profile):
+    for result in resolve_url_stream(
+        url, max_chars, profile, query=query, skip_providers=skip_providers
+    ):
         if result.get("source") != "partial":
             return result
     return {"source": "none", "url": url, "content": "Failed"}
 
 
 def resolve_url_stream(
-    url: str, max_chars: int = 8000, profile: Profile = Profile.BALANCED
+    url: str,
+    max_chars: int = 8000,
+    profile: Profile = Profile.BALANCED,
+    query: str | None = None,
+    skip_providers: set[str] | None = None,
 ) -> Generator[dict[str, Any]]:
     logger.info(f"Resolving URL: {url}")
 
@@ -119,7 +130,7 @@ def resolve_url_stream(
             return
 
     provider_names = scripts.routing.plan_provider_order(
-        target=url, is_url=True, routing_memory=_routing_memory
+        target=url, is_url=True, routing_memory=_routing_memory, skip_providers=skip_providers
     )
     cascade_map: dict[str, tuple[ProviderType, Any]] = {
         "llms_txt": (ProviderType.LLMS_TXT, lambda: fetch_llms_txt(url)),
@@ -132,6 +143,10 @@ def resolve_url_stream(
         "mistral_browser": (
             ProviderType.MISTRAL_BROWSER,
             lambda: resolve_with_mistral_browser(url, max_chars),
+        ),
+        "visual_clip": (
+            ProviderType.VISUAL_CLIP,
+            lambda: resolve_with_visual_clip(url, max_chars, query=query),
         ),
         "duckduckgo": (ProviderType.DUCKDUCKGO, lambda: resolve_with_duckduckgo(url, max_chars)),
     }

--- a/scripts/_url_resolve_async.py
+++ b/scripts/_url_resolve_async.py
@@ -9,6 +9,7 @@ import scripts.routing
 from scripts._cascade_async import cascade_stream_async
 from scripts.models import Profile, ProviderType, ResolvedResult, ResolveMetrics
 from scripts.providers.jina import resolve_with_jina_async
+from scripts.providers.visual_clip import resolve_with_visual_clip_async
 from scripts.semantic_cache import get_semantic_cache
 from scripts.state import circuit_breakers as _circuit_breakers
 from scripts.state import routing_memory as _routing_memory
@@ -18,17 +19,27 @@ logger = logging.getLogger(__name__)
 
 
 async def resolve_url_async(
-    url: str, max_chars: int = 8000, profile: Profile = Profile.BALANCED
+    url: str,
+    max_chars: int = 8000,
+    profile: Profile = Profile.BALANCED,
+    query: str | None = None,
+    skip_providers: set[str] | None = None,
 ) -> dict[str, Any]:
     """Async version of resolve_url."""
-    async for result in resolve_url_stream_async(url, max_chars, profile):
+    async for result in resolve_url_stream_async(
+        url, max_chars, profile, query=query, skip_providers=skip_providers
+    ):
         if result.get("source") != "partial":
             return result
     return {"source": "none", "url": url, "content": "Failed"}
 
 
 async def resolve_url_stream_async(
-    url: str, max_chars: int = 8000, profile: Profile = Profile.BALANCED
+    url: str,
+    max_chars: int = 8000,
+    profile: Profile = Profile.BALANCED,
+    query: str | None = None,
+    skip_providers: set[str] | None = None,
 ) -> AsyncGenerator[dict[str, Any]]:
     """Async generator version of resolve_url_stream."""
     logger.info(f"Resolving URL async: {url}")
@@ -52,12 +63,16 @@ async def resolve_url_stream_async(
     )
 
     provider_names = scripts.routing.plan_provider_order(
-        target=url, is_url=True, routing_memory=_routing_memory
+        target=url, is_url=True, routing_memory=_routing_memory, skip_providers=skip_providers
     )
 
     # Async provider map - only async providers for now
     cascade_map: dict[str, tuple[ProviderType, Any]] = {
         "jina": (ProviderType.JINA, lambda: resolve_with_jina_async(url, max_chars)),
+        "visual_clip": (
+            ProviderType.VISUAL_CLIP,
+            lambda: resolve_with_visual_clip_async(url, max_chars, query=query),
+        ),
         # TODO: Add async versions of other providers
         # "firecrawl": (ProviderType.FIRECRAWL, lambda: resolve_with_firecrawl_async(url, max_chars)),
         # "direct_fetch": (ProviderType.DIRECT_FETCH, lambda: fetch_url_content_async(url, max_chars)),
@@ -73,7 +88,9 @@ async def resolve_url_stream_async(
         logger.info("No async providers eligible, falling back to sync cascade")
         from scripts._url_resolve import resolve_url_stream
 
-        for result in resolve_url_stream(url, max_chars, profile):
+        for result in resolve_url_stream(
+            url, max_chars, profile, query=query, skip_providers=skip_providers
+        ):
             yield result
         return
 

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -33,7 +33,9 @@ async def _async_main(args):
         if is_url(args.input):
             # Use async URL resolver
             results = []
-            async for res in resolve_url_stream_async(args.input, args.max_chars, profile):
+            async for res in resolve_url_stream_async(
+                args.input, args.max_chars, profile, skip_providers=skip
+            ):
                 results.append(res)
         else:
             results = list(resolve_query_stream(args.input, args.max_chars, skip, profile))
@@ -49,7 +51,7 @@ def main():
         "--profile", type=str, choices=[p.value for p in Profile], default="balanced"
     )
     parser.add_argument("--skip", action="append")
-    parser.add_argument("--provider", type=str)
+    parser.add_argument("--provider", type=str, choices=[p.value for p in ProviderType])
     parser.add_argument("--providers-order", type=str)
     parser.add_argument("--log-level", default="INFO")
     args = parser.parse_args()

--- a/scripts/models.py
+++ b/scripts/models.py
@@ -71,6 +71,7 @@ class ProviderType(Enum):
     # New providers
     DOCLING = "docling"
     OCR = "ocr"
+    VISUAL_CLIP = "visual_clip"
 
     def is_paid(self) -> bool:
         return self in (
@@ -80,6 +81,7 @@ class ProviderType(Enum):
             ProviderType.FIRECRAWL,
             ProviderType.MISTRAL_WEBSEARCH,
             ProviderType.MISTRAL_BROWSER,
+            ProviderType.VISUAL_CLIP,
         )
 
     def is_fast(self) -> bool:

--- a/scripts/providers/__init__.py
+++ b/scripts/providers/__init__.py
@@ -13,6 +13,10 @@ from scripts.providers.jina import resolve_with_jina
 from scripts.providers.mistral import resolve_with_mistral_browser, resolve_with_mistral_websearch
 from scripts.providers.serper import resolve_with_serper
 from scripts.providers.tavily import resolve_with_tavily
+from scripts.providers.visual_clip import (
+    resolve_with_visual_clip,
+    resolve_with_visual_clip_async,
+)
 
 # Rate limiting functions
 _rate_limits: dict[str, float] = {}
@@ -54,6 +58,8 @@ __all__ = [
     "resolve_with_mistral_websearch",
     "resolve_with_docling",
     "resolve_with_ocr",
+    "resolve_with_visual_clip",
+    "resolve_with_visual_clip_async",
     "_is_rate_limited",
     "_set_rate_limit",
     "_clear_rate_limits",

--- a/scripts/providers/visual_clip.py
+++ b/scripts/providers/visual_clip.py
@@ -1,0 +1,118 @@
+"""
+Visual CLIP provider implementation.
+"""
+
+import logging
+import os
+
+from scripts.constants import MAX_CHARS
+from scripts.models import ResolvedResult
+from scripts.utils import _get_from_cache, _save_to_cache, is_safe_url
+from scripts.visual_resolver import VisualResolver
+
+logger = logging.getLogger(__name__)
+
+_visual_resolver: "VisualResolver | None" = None
+
+
+def get_visual_resolver() -> VisualResolver:
+    """Lazy initialization of the VisualResolver."""
+    global _visual_resolver
+    if _visual_resolver is None:
+        _visual_resolver = VisualResolver()
+    return _visual_resolver
+
+
+def _is_api_available() -> bool:
+    """Check if required API keys for VLM are present."""
+    return bool(os.getenv("MISTRAL_API_KEY") or os.getenv("OPENROUTER_API_KEY"))
+
+
+def resolve_with_visual_clip(
+    url: str, max_chars: int = MAX_CHARS, query: str | None = None
+) -> ResolvedResult | None:
+    """
+    Resolve a URL using the Visual CLIP resolver (sync).
+    """
+    if not is_safe_url(url):
+        logger.warning("SSRF blocked: %s", url)
+        return None
+
+    if not _is_api_available():
+        logger.debug("Visual CLIP skipped: no API key")
+        return None
+
+    resolver = get_visual_resolver()
+    if not resolver.is_available():
+        logger.debug("Visual CLIP skipped: dependencies missing or disabled")
+        return None
+
+    cached = _get_from_cache(url, "visual_clip")
+    if cached:
+        return ResolvedResult(**cached)
+
+    effective_query = query or "Extract the main content of this page."
+
+    try:
+        res = resolver.resolve(url, effective_query)
+        if not res or res.content is None:
+            return None
+
+        result = ResolvedResult(
+            source="visual_clip",
+            content=res.content[:max_chars],
+            url=url,
+            query=effective_query,
+            score=res.score,
+            metadata=res.metadata,
+        )
+        _save_to_cache(url, "visual_clip", result.to_dict())
+        return result
+    except Exception as e:
+        logger.warning("Visual CLIP resolution failed: %s", e)
+        return None
+
+
+async def resolve_with_visual_clip_async(
+    url: str, max_chars: int = MAX_CHARS, query: str | None = None
+) -> ResolvedResult | None:
+    """
+    Resolve a URL using the Visual CLIP resolver (async).
+    """
+    if not is_safe_url(url):
+        logger.warning("SSRF blocked: %s", url)
+        return None
+
+    if not _is_api_available():
+        logger.debug("Visual CLIP skipped: no API key")
+        return None
+
+    resolver = get_visual_resolver()
+    if not resolver.is_available():
+        logger.debug("Visual CLIP skipped: dependencies missing or disabled")
+        return None
+
+    cached = _get_from_cache(url, "visual_clip")
+    if cached:
+        return ResolvedResult(**cached)
+
+    effective_query = query or "Extract the main content of this page."
+
+    try:
+        res = await resolver.resolve_async(url, effective_query)
+        if not res or res.content is None:
+            return None
+
+        result = ResolvedResult(
+            source="visual_clip",
+            content=res.content[:max_chars],
+            url=url,
+            query=effective_query,
+            score=res.score,
+            metadata=res.metadata,
+        )
+        _save_to_cache(url, "visual_clip", result.to_dict())
+        return result
+    except Exception as e:
+        logger.warning("Visual CLIP resolution failed: %s", e)
+        return None

--- a/scripts/providers_impl.py
+++ b/scripts/providers_impl.py
@@ -21,6 +21,8 @@ from scripts.providers import (
     resolve_with_ocr,
     resolve_with_serper,
     resolve_with_tavily,
+    resolve_with_visual_clip,
+    resolve_with_visual_clip_async,
     set_rate_limit,
 )
 from scripts.utils import get_session
@@ -37,6 +39,8 @@ __all__ = [
     "resolve_with_mistral_websearch",
     "resolve_with_docling",
     "resolve_with_ocr",
+    "resolve_with_visual_clip",
+    "resolve_with_visual_clip_async",
     "_is_rate_limited",
     "_set_rate_limit",
     "_clear_rate_limits",

--- a/scripts/resolve.py
+++ b/scripts/resolve.py
@@ -37,6 +37,7 @@ from scripts.providers_impl import (
     resolve_with_ocr,
     resolve_with_serper,
     resolve_with_tavily,
+    resolve_with_visual_clip,
 )
 from scripts.semantic_cache import get_semantic_cache
 from scripts.state import circuit_breakers, routing_memory
@@ -144,12 +145,15 @@ def resolve(
     max_chars: int = MAX_CHARS,
     skip_providers: set[str] | None = None,
     profile: Profile | str = Profile.BALANCED,
+    query: str | None = None,
 ) -> dict[str, Any]:
     if isinstance(profile, str):
         profile = Profile(profile.lower())
 
     if is_url(input_str):
-        return resolve_url(input_str, max_chars, profile=profile)
+        return resolve_url(
+            input_str, max_chars, profile=profile, query=query, skip_providers=skip_providers
+        )
     return resolve_query(input_str, max_chars, skip_providers, profile=profile)
 
 
@@ -174,6 +178,7 @@ def resolve_direct(
         ProviderType.SERPER: resolve_with_serper,
         ProviderType.DOCLING: resolve_with_docling,
         ProviderType.OCR: resolve_with_ocr,
+        ProviderType.VISUAL_CLIP: resolve_with_visual_clip,
     }
     if provider in funcs:
         res = funcs[provider](input_str, max_chars)
@@ -207,12 +212,18 @@ def resolve_query_with_order(
 
 
 async def resolve_url_async(
-    url: str, max_chars: int = MAX_CHARS, profile: Profile | str = Profile.BALANCED
+    url: str,
+    max_chars: int = MAX_CHARS,
+    profile: Profile | str = Profile.BALANCED,
+    query: str | None = None,
+    skip_providers: set[str] | None = None,
 ) -> dict[str, Any]:
     """Async version of resolve_url."""
     if isinstance(profile, str):
         profile = Profile(profile.lower())
-    return await scripts._url_resolve_async.resolve_url_async(url, max_chars, profile)
+    return await scripts._url_resolve_async.resolve_url_async(
+        url, max_chars, profile, query=query, skip_providers=skip_providers
+    )
 
 
 async def resolve_async(
@@ -220,20 +231,29 @@ async def resolve_async(
     max_chars: int = MAX_CHARS,
     skip_providers: set[str] | None = None,
     profile: Profile | str = Profile.BALANCED,
+    query: str | None = None,
 ) -> dict[str, Any]:
     """Async version of resolve."""
     if isinstance(profile, str):
         profile = Profile(profile.lower())
     if is_url(input_str):
-        return await resolve_url_async(input_str, max_chars, profile=profile)
+        return await resolve_url_async(
+            input_str, max_chars, profile=profile, query=query, skip_providers=skip_providers
+        )
     return resolve_query(input_str, max_chars, skip_providers, profile=profile)
 
 
 def resolve_url_background(
-    url: str, max_chars: int = MAX_CHARS, profile: Profile | str = Profile.BALANCED
+    url: str,
+    max_chars: int = MAX_CHARS,
+    profile: Profile | str = Profile.BALANCED,
+    query: str | None = None,
+    skip_providers: set[str] | None = None,
 ) -> dict[str, Any]:
     """Run async resolve_url in a new event loop (for sync callers)."""
-    return asyncio.run(resolve_url_async(url, max_chars, profile))
+    return asyncio.run(
+        resolve_url_async(url, max_chars, profile, query=query, skip_providers=skip_providers)
+    )
 
 
 def resolve_background(

--- a/scripts/routing.py
+++ b/scripts/routing.py
@@ -203,24 +203,33 @@ def plan_provider_order(
         strategy = preflight.get("preferred_strategy", "llms_txt")
 
         if platform in ("notion", "confluence") or preflight.get("js_heavy"):
-            base = ["mistral_browser", "jina", "direct_fetch", "duckduckgo", "firecrawl"]
+            base = [
+                "jina",
+                "firecrawl",
+                "visual_clip",
+                "mistral_browser",
+                "direct_fetch",
+                "duckduckgo",
+            ]
         elif strategy == "direct_fetch":
             base = [
                 "direct_fetch",
                 "llms_txt",
                 "jina",
+                "firecrawl",
+                "visual_clip",
                 "mistral_browser",
                 "duckduckgo",
-                "firecrawl",
             ]
         else:
             base = [
                 "llms_txt",
                 "jina",
-                "direct_fetch",
-                "mistral_browser",
-                "duckduckgo",
                 "firecrawl",
+                "visual_clip",
+                "mistral_browser",
+                "direct_fetch",
+                "duckduckgo",
             ]
     else:
         # DuckDuckGo deprioritized due to instability (Alert 2026-04-20)

--- a/tests/test_resolve_visual.py
+++ b/tests/test_resolve_visual.py
@@ -1,0 +1,123 @@
+"""
+Tests for Visual CLIP provider integration.
+"""
+
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.models import Profile, ProviderType
+
+
+class TestVisualClipIntegration:
+    """Test the integration of visual_clip provider in the cascade."""
+
+    @patch.dict(os.environ, {"MISTRAL_API_KEY": "test_key"})
+    @patch("scripts.providers.visual_clip.get_visual_resolver")
+    @patch("scripts.routing.plan_provider_order", return_value=["visual_clip"])
+    @patch("scripts._url_resolve.get_semantic_cache", return_value=None)
+    def test_visual_clip_in_sync_cascade(self, mock_cache, mock_plan, mock_get_resolver):
+        """Test that visual_clip is called in the sync cascade when others are skipped."""
+        # Setup mock resolver
+        mock_resolver = mock_get_resolver.return_value
+        mock_resolver.is_available.return_value = True
+
+        from scripts.visual_resolver import ProviderResult
+
+        mock_resolver.resolve.return_value = ProviderResult(
+            content="Visual content from the page that is long enough to pass the quality gate and contains enough information to be useful for the user. "
+            * 10,
+            score=0.9,
+            provider="visual_clip",
+            metadata={"clip_score": 0.9},
+        )
+
+        # Import resolve here to pick up the patch
+        from scripts.resolve import resolve_url
+
+        # Execute resolution
+        url = "https://example.com/image-heavy"
+        query = "find the chart"
+        result = resolve_url(url, query=query, profile=Profile.BALANCED)
+
+        # Verify visual_clip was called
+        assert result["source"] == "visual_clip"
+        assert "Visual content" in result["content"]
+        mock_resolver.resolve.assert_called_once_with(url, query)
+
+    @patch.dict(os.environ, {"OPENROUTER_API_KEY": "test_key"})
+    @patch("scripts.providers.visual_clip.get_visual_resolver")
+    @patch("scripts.routing.plan_provider_order", return_value=["visual_clip"])
+    @patch("scripts._url_resolve_async.get_semantic_cache", return_value=None)
+    def test_visual_clip_in_async_cascade(self, mock_cache, mock_plan, mock_get_resolver):
+        """Test that visual_clip is called in the async cascade when others are skipped."""
+        # Setup mock resolver
+        mock_resolver = mock_get_resolver.return_value
+        mock_resolver.is_available.return_value = True
+
+        from scripts.visual_resolver import ProviderResult
+
+        # Mock async resolve
+        mock_resolver.resolve_async = AsyncMock(
+            return_value=ProviderResult(
+                content="Async visual content from the page that is long enough to pass the quality gate and contains enough information to be useful for the user. "
+                * 10,
+                score=0.95,
+                provider="visual_clip",
+                metadata={"clip_score": 0.95},
+            )
+        )
+
+        # Import resolve here to pick up the patch
+        from scripts.resolve import resolve_url_async
+
+        # Execute resolution
+        url = "https://example.com/async-image"
+        query = "describe the image"
+
+        result = asyncio.run(resolve_url_async(url, query=query, profile=Profile.BALANCED))
+
+        # Verify visual_clip was called
+        assert result["source"] == "visual_clip"
+        assert "Async visual content" in result["content"]
+        mock_resolver.resolve_async.assert_called_once_with(url, query)
+
+    def test_provider_type_enum(self):
+        """Verify VISUAL_CLIP is in ProviderType and correctly configured."""
+        assert ProviderType.VISUAL_CLIP.value == "visual_clip"
+        assert ProviderType.VISUAL_CLIP.is_paid()
+        assert not ProviderType.VISUAL_CLIP.is_fast()
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("scripts.providers.visual_clip.VisualResolver")
+    def test_visual_clip_skipped_without_api_key(self, mock_resolver_class):
+        """Test that visual_clip is skipped when no API key is present."""
+        from scripts.providers.visual_clip import resolve_with_visual_clip
+
+        result = resolve_with_visual_clip("https://example.com")
+        assert result is None
+        mock_resolver_class.assert_not_called()
+
+    @patch.dict(os.environ, {"MISTRAL_API_KEY": "test_key"})
+    @patch("scripts.providers.visual_clip.get_visual_resolver")
+    def test_resolve_direct_visual_clip(self, mock_get_resolver):
+        """Test resolve_direct with visual_clip."""
+        from scripts.resolve import resolve_direct
+
+        mock_resolver = mock_get_resolver.return_value
+        mock_resolver.is_available.return_value = True
+
+        from scripts.visual_resolver import ProviderResult
+
+        mock_resolver.resolve.return_value = ProviderResult(
+            content="Direct visual content from the page that is long enough to pass the quality gate.",
+            score=0.8,
+            provider="visual_clip",
+        )
+
+        result = resolve_direct("https://example.com", ProviderType.VISUAL_CLIP)
+        assert result["source"] == "visual_clip"
+        assert "Direct visual content" in result["content"]


### PR DESCRIPTION
Integrated the `visual_clip` provider from the `do-wdr-visual-resolver` skill into the core URL resolution cascade.

Key changes:
1.  **Model Update**: Added `VISUAL_CLIP` to `ProviderType` in `scripts/models.py` and marked it as a paid provider.
2.  **Provider Implementation**: Created `scripts/providers/visual_clip.py` which wraps the `VisualResolver`. It handles both sync and async calls and implements availability checks based on API keys.
3.  **Routing Logic**: Modified `scripts/routing.py` to place `visual_clip` in the resolution order: `jina` -> `firecrawl` -> `visual_clip` -> `mistral_browser` -> `direct_fetch`.
4.  **Cascade Wiring**: Updated `scripts/_url_resolve.py` and `scripts/_url_resolve_async.py` to include `visual_clip` in their respective cascade maps.
5.  **Query Support**: Enhanced `resolve_url` and related functions to accept an optional `query` parameter, which is required by the visual resolver to identify relevant parts of the page.
6.  **Verification**: Added unit and integration tests in `tests/test_resolve_visual.py` to ensure correct wiring and behavior of the new provider within the cascade.

Fixes #476

---
*PR created automatically by Jules for task [4254538993565340695](https://jules.google.com/task/4254538993565340695) started by @d-oit*