### PR TITLE
fix(security): harden BLOCKED_NETWORKS with cloud metadata endpoints

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/constants.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/constants.py
@@ -78,14 +78,37 @@ USER_AGENT: str = (
 
 BLOCKED_NETWORKS: list = [
     ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("0.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("192.0.0.0/24"),
+    ipaddress.ip_network("198.18.0.0/15"),
+    ipaddress.ip_network("198.51.100.0/24"),
+    ipaddress.ip_network("203.0.113.0/24"),
+    ipaddress.ip_network("240.0.0.0/4"),
+    ipaddress.ip_network("255.255.255.255/32"),
+    ipaddress.ip_network("::ffff:0:0/96"),
 ]
+
+BLOCKED_HOSTNAMES: frozenset[str] = frozenset(
+    [
+        "metadata.google.internal",
+        "metadata.google",
+        "metadata.azure.com",
+        "169.254.169.254",
+        "kubernetes.default.svc",
+        "kubernetes.default",
+        "kubernetes",
+        "host.docker.internal",
+        "gateway.docker.internal",
+    ]
+)
 
 BLOCKED_SCHEMES: set[str] = {"file", "javascript", "data", "vbscript"}
 

--- a/.agents/skills/do-web-doc-resolver/scripts/utils.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/utils.py
@@ -22,6 +22,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from scripts.constants import (
+    BLOCKED_HOSTNAMES,
     BLOCKED_NETWORKS,
     BLOCKED_SCHEMES,
     CACHE_DIR,
@@ -156,6 +157,24 @@ def _getaddrinfo_cached(host: str, port: int | str | None = None) -> list[tuple]
     return _getaddrinfo_bucketed(host, port, bucket)
 
 
+def _normalize_host(hostname: str) -> str:
+    """Normalise encoded IP representations to dotted-decimal."""
+    h = hostname.strip().lower()
+    if h.isdigit():
+        try:
+            return str(ipaddress.IPv4Address(int(h)))
+        except (ValueError, OverflowError):
+            pass
+    if h.startswith("0x"):
+        try:
+            return str(ipaddress.IPv4Address(int(h, 16)))
+        except (ValueError, OverflowError):
+            pass
+    if h.startswith("::ffff:"):
+        return h[7:]
+    return h
+
+
 def is_safe_url(url: str) -> bool:
     try:
         parsed = urlparse(url)
@@ -166,7 +185,7 @@ def is_safe_url(url: str) -> bool:
         hostname = parsed.hostname
         if not hostname:
             return False
-        normalized = hostname.lower()
+        normalized = _normalize_host(hostname)
         if normalized in (
             "localhost",
             "localhost.localdomain",
@@ -174,6 +193,11 @@ def is_safe_url(url: str) -> bool:
             "::1",
             "0.0.0.0",
         ):
+            return False
+        hostname_lower = hostname.lower().strip(".")
+        if hostname_lower in BLOCKED_HOSTNAMES:
+            return False
+        if any(hostname_lower.endswith("." + blocked) for blocked in BLOCKED_HOSTNAMES):
             return False
         try:
             ip = ipaddress.ip_address(normalized)

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -78,14 +78,37 @@ USER_AGENT: str = (
 
 BLOCKED_NETWORKS: list = [
     ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("0.0.0.0/8"),
     ipaddress.ip_network("10.0.0.0/8"),
     ipaddress.ip_network("172.16.0.0/12"),
     ipaddress.ip_network("192.168.0.0/16"),
     ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
     ipaddress.ip_network("fe80::/10"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("192.0.0.0/24"),
+    ipaddress.ip_network("198.18.0.0/15"),
+    ipaddress.ip_network("198.51.100.0/24"),
+    ipaddress.ip_network("203.0.113.0/24"),
+    ipaddress.ip_network("240.0.0.0/4"),
+    ipaddress.ip_network("255.255.255.255/32"),
+    ipaddress.ip_network("::ffff:0:0/96"),
 ]
+
+BLOCKED_HOSTNAMES: frozenset[str] = frozenset(
+    [
+        "metadata.google.internal",
+        "metadata.google",
+        "metadata.azure.com",
+        "169.254.169.254",
+        "kubernetes.default.svc",
+        "kubernetes.default",
+        "kubernetes",
+        "host.docker.internal",
+        "gateway.docker.internal",
+    ]
+)
 
 BLOCKED_SCHEMES: set[str] = {"file", "javascript", "data", "vbscript"}
 

--- a/scripts/utils/async_http.py
+++ b/scripts/utils/async_http.py
@@ -14,6 +14,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 
 from scripts.constants import (
+    BLOCKED_HOSTNAMES,
     BLOCKED_NETWORKS,
     BLOCKED_SCHEMES,
     DNS_CACHE_TTL,
@@ -70,6 +71,24 @@ def _getaddrinfo_cached(host: str, port: int | str | None = None) -> list[tuple]
     return _getaddrinfo_bucketed(host, port, bucket)
 
 
+def _normalize_host(hostname: str) -> str:
+    """Normalise encoded IP representations to dotted-decimal."""
+    h = hostname.strip().lower()
+    if h.isdigit():
+        try:
+            return str(ipaddress.IPv4Address(int(h)))
+        except (ValueError, OverflowError):
+            pass
+    if h.startswith("0x"):
+        try:
+            return str(ipaddress.IPv4Address(int(h, 16)))
+        except (ValueError, OverflowError):
+            pass
+    if h.startswith("::ffff:"):
+        return h[7:]
+    return h
+
+
 def is_safe_url(url: str) -> bool:
     """Check if a URL is safe to fetch (no SSRF)."""
     try:
@@ -81,7 +100,7 @@ def is_safe_url(url: str) -> bool:
         hostname = parsed.hostname
         if not hostname:
             return False
-        normalized = hostname.lower()
+        normalized = _normalize_host(hostname)
         if normalized in (
             "localhost",
             "localhost.localdomain",
@@ -89,6 +108,13 @@ def is_safe_url(url: str) -> bool:
             "::1",
             "0.0.0.0",
         ):
+            return False
+        hostname_lower = hostname.lower().strip(".")
+        if hostname_lower in BLOCKED_HOSTNAMES:
+            logger.warning("SSRF blocked (hostname blocklist): %s", url)
+            return False
+        if any(hostname_lower.endswith("." + blocked) for blocked in BLOCKED_HOSTNAMES):
+            logger.warning("SSRF blocked (hostname suffix): %s", url)
             return False
         try:
             ip = ipaddress.ip_address(normalized)

--- a/scripts/utils/http.py
+++ b/scripts/utils/http.py
@@ -15,6 +15,7 @@ from urllib.parse import urljoin, urlparse
 import httpx
 
 from scripts.constants import (
+    BLOCKED_HOSTNAMES,
     BLOCKED_NETWORKS,
     BLOCKED_SCHEMES,
     DNS_CACHE_TTL,
@@ -83,6 +84,27 @@ def _getaddrinfo_cached(host: str, port: int | str | None = None) -> list[tuple]
     return _getaddrinfo_bucketed(host, port, bucket)
 
 
+def _normalize_host(hostname: str) -> str:
+    """Normalise encoded IP representations to dotted-decimal.
+
+    Handles decimal integer notation, hex notation, and IPv4-mapped IPv6.
+    """
+    h = hostname.strip().lower()
+    if h.isdigit():
+        try:
+            return str(ipaddress.IPv4Address(int(h)))
+        except (ValueError, OverflowError):
+            pass
+    if h.startswith("0x"):
+        try:
+            return str(ipaddress.IPv4Address(int(h, 16)))
+        except (ValueError, OverflowError):
+            pass
+    if h.startswith("::ffff:"):
+        return h[7:]
+    return h
+
+
 def is_safe_url(url: str) -> bool:
     """Check if a URL is safe to fetch (no SSRF)."""
     try:
@@ -94,7 +116,7 @@ def is_safe_url(url: str) -> bool:
         hostname = parsed.hostname
         if not hostname:
             return False
-        normalized = hostname.lower()
+        normalized = _normalize_host(hostname)
         if normalized in (
             "localhost",
             "localhost.localdomain",
@@ -102,6 +124,13 @@ def is_safe_url(url: str) -> bool:
             "::1",
             "0.0.0.0",
         ):
+            return False
+        hostname_lower = hostname.lower().strip(".")
+        if hostname_lower in BLOCKED_HOSTNAMES:
+            logger.warning("SSRF blocked (hostname blocklist): %s", url)
+            return False
+        if any(hostname_lower.endswith("." + blocked) for blocked in BLOCKED_HOSTNAMES):
+            logger.warning("SSRF blocked (hostname suffix): %s", url)
             return False
         try:
             ip = ipaddress.ip_address(normalized)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,6 +111,42 @@ class TestIsSafeUrl:
     def test_normal_public_ip_safe(self):
         assert is_safe_url("https://8.8.8.8") is True
 
+    def test_gcp_metadata_hostname_blocked(self):
+        assert is_safe_url("http://metadata.google.internal/computeMetadata/v1/") is False
+
+    def test_azure_metadata_hostname_blocked(self):
+        assert is_safe_url("http://metadata.azure.com/metadata/instance") is False
+
+    def test_k8s_api_hostname_blocked(self):
+        assert is_safe_url("http://kubernetes.default.svc/api/v1") is False
+
+    def test_docker_internal_hostname_blocked(self):
+        assert is_safe_url("http://host.docker.internal:8080/") is False
+
+    def test_decimal_ip_blocked(self):
+        assert is_safe_url("http://2130706433/") is False
+
+    def test_hex_ip_blocked(self):
+        assert is_safe_url("http://0x7f000001/") is False
+
+    def test_carrier_grade_nat_blocked(self):
+        assert is_safe_url("http://100.64.0.1/") is False
+
+    def test_reserved_network_blocked(self):
+        assert is_safe_url("http://198.18.0.1/") is False
+
+    def test_test_net_2_blocked(self):
+        assert is_safe_url("http://198.51.100.1/") is False
+
+    def test_test_net_3_blocked(self):
+        assert is_safe_url("http://203.0.113.1/") is False
+
+    def test_broadcast_address_blocked(self):
+        assert is_safe_url("http://255.255.255.255/") is False
+
+    def test_metadata_suffix_blocked(self):
+        assert is_safe_url("http://sub.metadata.google.internal/v1/") is False
+
 
 # ─── normalize_query ──────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Hardens the SSRF protection layer with three concrete changes to close bypass vectors:

1. **Expand `BLOCKED_NETWORKS`** from 8 to 17 entries — adds `0.0.0.0/8`, `100.64.0.0/10` (Carrier-grade NAT/Tailscale), `192.0.0.0/24`, `198.18.0.0/15`, `198.51.100.0/24`, `203.0.113.0/24`, `240.0.0.0/4`, `255.255.255.255/32`, and `::ffff:0:0/96` (IPv4-mapped IPv6)

2. **Add `BLOCKED_HOSTNAMES`** frozenset with 9 cloud/k8s metadata hostnames that bypass IP-based checks: `metadata.google.internal`, `metadata.azure.com`, `kubernetes.default.svc`, `host.docker.internal`, etc.

3. **Add `_normalize_host()`** to detect encoded IP bypasses: decimal (`2130706433` → `127.0.0.1`), hex (`0x7f000001` → `127.0.0.1`), and IPv4-mapped IPv6 (`::ffff:127.0.0.1`)

## Changes

| File | Change |
|------|--------|
| `scripts/constants.py` | Expand `BLOCKED_NETWORKS` (8→17), add `BLOCKED_HOSTNAMES` |
| `scripts/utils/http.py` | Add `_normalize_host()`, hostname blocklist check in `is_safe_url` |
| `scripts/utils/async_http.py` | Same changes as sync variant |
| `tests/test_utils.py` | 12 new test cases for hostname blocklist and encoded IP bypasses |
| `.agents/skills/*/` | Updated skills snapshot to match |

## Test Results

- **30/30** `is_safe_url` tests pass (18 existing + 12 new)
- **369/369** non-live tests pass
- **89/89** Rust CLI tests pass
- Ruff, Black, mypy, Clippy all clean

## Security Impact

| Attack Vector | Before | After |
|---|---|---|
| `metadata.google.internal` (GCP IMDS) | Not blocked | Blocked |
| `metadata.azure.com` (Azure IMDS) | Not blocked | Blocked |
| `kubernetes.default.svc` (K8s API) | Not blocked | Blocked |
| `http://2130706433/` (decimal 127.0.0.1) | Not blocked | Blocked |
| `http://0x7f000001/` (hex 127.0.0.1) | Not blocked | Blocked |
| `100.64.0.0/10` (Tailscale range) | Not blocked | Blocked |

Closes #492