### PR TITLE
fix(resolver): preserve indentation in direct_fetch code blocks

### DIFF
--- a/cli/src/providers/direct_fetch.rs
+++ b/cli/src/providers/direct_fetch.rs
@@ -487,11 +487,24 @@ fn strip_html(html: &str) -> String {
     // Clean up whitespace
     let mut final_result = String::new();
     let mut last_was_empty = false;
+    let mut in_code_block = false;
 
     for line in decoded.lines() {
-        let trimmed = line.trim();
+        let is_code_fence = line.trim_start().starts_with("```");
+        let trimmed = if is_code_fence {
+            in_code_block = !in_code_block;
+            line.trim()
+        } else if in_code_block {
+            line.trim_end()
+        } else {
+            line.trim()
+        };
+
         if trimmed.is_empty() {
-            if !last_was_empty && !final_result.is_empty() {
+            if in_code_block {
+                final_result.push('\n');
+                last_was_empty = false;
+            } else if !last_was_empty && !final_result.is_empty() {
                 final_result.push_str("\n\n");
                 last_was_empty = true;
             }


### PR DESCRIPTION
The `direct_fetch` provider in the Rust CLI was aggressively trimming leading whitespace from all lines, which caused indentation loss in Markdown code blocks. This fix introduces a state-aware line processor in the `strip_html` function that identifies Markdown code fences and switches to `trim_end()` (preserving leading whitespace) when inside a code block. It also ensures that empty lines within code blocks are not collapsed into paragraph breaks.

Key changes:
- Track `in_code_block` state during whitespace cleanup in `cli/src/providers/direct_fetch.rs`.
- Preserve indentation for lines inside code blocks.
- Preserve empty lines inside code blocks.
- Full integration test suite passes, including the nightly bridge indentation check.

---
*PR created automatically by Jules for task [15371189689602509473](https://jules.google.com/task/15371189689602509473) started by @d-oit*