### PR TITLE
fix(resolver): combine and re-score query results on semantic cache hit

### DIFF
--- a/cli/src/resolver/query/mod.rs
+++ b/cli/src/resolver/query/mod.rs
@@ -111,7 +111,7 @@ impl QueryCascade {
             if let Ok(Some(results)) = cache.query(query).await {
                 if !results.is_empty() {
                     let cache_latency = start_time.elapsed().as_millis() as u64;
-                    let mut first = results[0].clone();
+                    let mut first = Self::combine_cache_results(&results);
                     metrics.record_semantic_cache_hit(cache_latency, first.score);
                     first.metrics = Some(metrics);
                     return Ok(first);
@@ -477,6 +477,22 @@ impl QueryCascade {
             Duration::from_secs(ttl_secs),
             HashMap::new(),
         );
+    }
+
+    /// Combine all cache-hit result chunks into one and re-score it, so the
+    /// hit path assigns a score exactly like the cache-miss path does.
+    fn combine_cache_results(results: &[ResolvedResult]) -> ResolvedResult {
+        let mut first = results[0].clone();
+        if results.len() > 1 {
+            let combined_content = results
+                .iter()
+                .filter_map(|r| r.content.as_deref())
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            first.content = Some(combined_content);
+            first.score = score_result(&first.url, first.content.as_deref().unwrap_or(""));
+        }
+        first
     }
 }
 


### PR DESCRIPTION
This PR resolves a discrepancy in the query cascade semantic cache where cache hits on multi-result queries returned only the first uncombined result with lower quality scores, causing the quality synthesis score to fall below 0.85. On cache hit, we now combine and re-score the results exactly as done on cache misses to ensure high quality and score parity.

---
*PR created automatically by Jules for task [14490446812349354588](https://jules.google.com/task/14490446812349354588) started by @d-oit*