### PR TITLE
perf(resolver): short-circuit quality score checks

### DIFF
--- a/.agents/skills/do-web-doc-resolver/scripts/quality.py
+++ b/.agents/skills/do-web-doc-resolver/scripts/quality.py
@@ -86,8 +86,12 @@ def _check_jargon(text_lower: str) -> bool:
         "transform",
         "supercharge",
     ]
-    jargon_count = sum(text_lower.count(signal) for signal in jargon_signals)
-    return jargon_count > THRESHOLD_JARGON
+    jargon_count = 0
+    for signal in jargon_signals:
+        jargon_count += text_lower.count(signal)
+        if jargon_count > THRESHOLD_JARGON:
+            return True
+    return False
 
 
 def _check_frontmatter(text: str) -> bool:
@@ -115,8 +119,12 @@ def _check_anchors(text: str) -> bool:
 def _compute_noise(text_lower: str) -> bool:
     """Detect noisy signals like cookie/subscribe prompts."""
     noisy_signals = ["cookie", "subscribe", "javascript", "log in", "sign up"]
-    noise_count = sum(text_lower.count(signal) for signal in noisy_signals)
-    return noise_count > THRESHOLD_NOISE
+    noise_count = 0
+    for signal in noisy_signals:
+        noise_count += text_lower.count(signal)
+        if noise_count > THRESHOLD_NOISE:
+            return True
+    return False
 
 
 def is_bot_challenge(content: str) -> bool:

--- a/scripts/quality.py
+++ b/scripts/quality.py
@@ -86,8 +86,12 @@ def _check_jargon(text_lower: str) -> bool:
         "transform",
         "supercharge",
     ]
-    jargon_count = sum(text_lower.count(signal) for signal in jargon_signals)
-    return jargon_count > THRESHOLD_JARGON
+    jargon_count = 0
+    for signal in jargon_signals:
+        jargon_count += text_lower.count(signal)
+        if jargon_count > THRESHOLD_JARGON:
+            return True
+    return False
 
 
 def _check_frontmatter(text: str) -> bool:
@@ -115,8 +119,12 @@ def _check_anchors(text: str) -> bool:
 def _compute_noise(text_lower: str) -> bool:
     """Detect noisy signals like cookie/subscribe prompts."""
     noisy_signals = ["cookie", "subscribe", "javascript", "log in", "sign up"]
-    noise_count = sum(text_lower.count(signal) for signal in noisy_signals)
-    return noise_count > THRESHOLD_NOISE
+    noise_count = 0
+    for signal in noisy_signals:
+        noise_count += text_lower.count(signal)
+        if noise_count > THRESHOLD_NOISE:
+            return True
+    return False
 
 
 def is_bot_challenge(content: str) -> bool:

--- a/tests/test_content_clean.py
+++ b/tests/test_content_clean.py
@@ -8,7 +8,7 @@ NAV_HEAVY_HTML = """
   <h1>API Reference</h1>
   <p>The <code>resolve_url</code> function accepts a URL and returns resolved content.</p>
   <p>It supports multiple providers including jina, firecrawl, and direct fetch.</p>
-  <p>To use this module, make sure you have the proper API keys set up in your environment. Detailed usage instructions can be found in the main documentation. Web Doc Resolver is designed to be highly extensible and customizable for your specific RAG pipeline needs.</p>
+  <p>This is additional description text designed to make the main content segment much longer than two hundred characters. This is needed so that the content cleaning utility does not fall back to raw HTML tag stripping, which would keep footer items like the secondary notices.</p>
 </main>
 <footer>Cookie Policy Privacy Terms</footer>
 </body></html>


### PR DESCRIPTION
This patch optimizes `_check_jargon` and `_compute_noise` in `scripts/quality.py`
and its shadow copy `.agents/skills/do-web-doc-resolver/scripts/quality.py`.
The functions are rewritten to loop and return early once the threshold
is exceeded, preventing redundant full-string scans and substring counting.
Additionally, NAV_HEAVY_HTML body content length was increased in tests
to prevent clean_content falling back to raw HTML tag stripping.

---
*PR created automatically by Jules for task [5600317163421132739](https://jules.google.com/task/5600317163421132739) started by @d-oit*