### PR TITLE
chore(ci): make dependabot PRs automerge-clean

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "build"
       include: "scope"
     ignore:
       - dependency-name: "*"
@@ -40,7 +40,7 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "build"
       include: "scope"
 
   # npm - web UI
@@ -63,7 +63,7 @@ updates:
           - "minor"
           - "patch"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "build"
       include: "scope"
 
   # npm - packages
@@ -86,7 +86,7 @@ updates:
           - "minor"
           - "patch"
     commit-message:
-      prefix: "build(deps)"
+      prefix: "build"
       include: "scope"
 
   # GitHub Actions

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -43,7 +43,33 @@ jobs:
     name: Lint PR title (squash-merge subject)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
+      - name: Normalize dependabot PR metadata
+        if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Squash-merge uses the PR title+body as the commit message; commitlint
+          # lints that on push to main. Dependabot's auto title has a doubled
+          # scope (prefix "build(deps)" + include "scope") and its body is ~65KB
+          # of release notes, both of which break commitlint. Normalize.
+          # NOTE: body is a fixed multi-line literal (a real blank line separates
+          # the two paragraphs); a literal "\n" would be stored verbatim by the
+          # API and still produce an over-length line on squash merge.
+          NORMALIZED_TITLE=$(printf '%s' "$PR_TITLE" | sed -E 's/^([a-z]+)\(([a-z]+)\)\(([a-z-]+)\):/\1(\2):/')
+          NORMALIZED_BODY="Automated dependency update from dependabot.
+
+          Bumps a grouped set of packages (see commit history for the full list of version changes)."
+          gh pr edit "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$NORMALIZED_TITLE" \
+            --body "$NORMALIZED_BODY"
+
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -62,6 +88,7 @@ jobs:
               @commitlint/config-conventional@19
 
       - name: Lint PR title against commitlint
+        if: github.actor != 'dependabot[bot]'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -81,6 +108,7 @@ jobs:
           echo "PR title is a valid conventional commit."
 
       - name: Enforce PR body length for squash merge compatibility
+        if: github.actor != 'dependabot[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,8 @@ Detailed reference material in `agents-docs/`:
 - Merge conflicts
 - Required reviews missing
 
+Dependabot PRs are normalized automatically by the `commitlint.yml` `lint-pr-title` workflow (title de-duped, body replaced with a short summary). Do NOT hand-edit dependabot PR titles/bodies or mark them as exceptions in `commitlint.config.cjs`; if a dependabot PR is blocked on the title/body check, re-run the workflow instead.
+
 ### Test Commands
 
 - **Python**: `pytest -m "not live"`


### PR DESCRIPTION
Weekly dependabot group PRs were born red in their own CI, suspending automerge:

1. `commitlint` rejects the auto title `build(deps)(deps): …` (doubled scope from `prefix: "build(deps)"` + `include: "scope"`).
2. The ~65KB release-note body exceeds the 2000-char PR body gate, and its long lines break commitlint `body-max-line-length` on squash merge.

Changes:

- `.github/dependabot.yml`: `prefix: "build(deps)"` → `"build"` for pip/cargo/npm groups (titles become `build(deps): …`). `github-actions` (`ci`) untouched.
- `.github/workflows/commitlint.yml` (`lint-pr-title` job): new `Normalize dependabot PR metadata` step (first, `if: github.actor == 'dependabot[bot]'`) rewrites title (scope de-duped, regex validated locally) and replaces body with a short fixed commitlint-clean summary; existing title/body gates now skip only `dependabot[bot]`; job-level `pull-requests: write` added for `gh pr edit`.
- `AGENTS.md`: document that dependabot titles/bodies are normalized automatically and must not be hand-edited.

Verified locally: raw doubled-scope title fails commitlint (exit 1), normalized passes (exit 0); full squash-merge message passes commitlint with all lines ≤100; `yamllint` + `actionlint` pass.

After merge, the next dependabot batch should arrive green and automerge to completion.
