### PR TITLE
fix(ci): remove dead dependabot npm /packages entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,29 +66,6 @@ updates:
       prefix: "build"
       include: "scope"
 
-  # npm - packages
-  - package-ecosystem: "npm"
-    directory: "/packages"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "frontend"
-    groups:
-      npm-packages-deps:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    commit-message:
-      prefix: "build"
-      include: "scope"
-
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Pre-existing dependabot config bug: the `/packages` update entry points at `packages/`, which was removed in `a28b362`. Every weekly scan fails with `/packages/package.json not found`, so that group never opens a PR and shows a failing `Dependabot` check on main.

This removes the dead entry. dependabot now scans only the four valid ecosystems (pip, cargo /cli, npm /web, github-actions), which are unaffected by this change.

Rationale: AGENTS.md requires green CI on main and fixing pre-existing failures; the dead entry was also surfaced when the previous `chore(ci)` PR (merged as `361b9b6`) pushed `dependabot.yml` and triggered the failing dependabot re-scan.
