### PR TITLE
ci(deps): auto-merge dependabot patch/minor PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+---
+name: Dependabot auto-merge
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only act on Dependabot PRs; never merge third-party changes unattended.
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Iron rule: auto-merge patch/minor only, route semver-major to a human.
+      # `--auto` is a reservation, not a force: GitHub only merges once the
+      # required status checks pass (strict branch protection gates this).
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-branch-autoupdate.yml
+++ b/.github/workflows/dependabot-branch-autoupdate.yml
@@ -1,0 +1,36 @@
+---
+name: Dependabot branch autoupdate
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    # Every 30 minutes: refresh Dependabot PR branches that fell behind base.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update stale Dependabot PR branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Auto-merge only fires once "require branches up to date before
+          # merging" is satisfied; merging group dependency update PRs advances
+          # main and leaves the other PRs BEHIND. Refresh them so their
+          # previously-enabled auto-merge can complete.
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --author "app/dependabot" \
+            --state open \
+            --json number,mergeStateStatus \
+            --jq '.[] | select(.mergeStateStatus == "BEHIND") | .number' \
+            | while read -r PR_NUMBER; do
+                echo "Updating dependabot PR #$PR_NUMBER (BEHIND)"
+                gh pr update-branch "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                  || echo "Update failed for #$PR_NUMBER (may have conflicts); leaving for human."
+              done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ Detailed reference material in `agents-docs/`:
 - Merge conflicts
 - Required reviews missing
 
-Dependabot PRs are normalized automatically by the `commitlint.yml` `lint-pr-title` workflow (title de-duped, body replaced with a short summary). Do NOT hand-edit dependabot PR titles/bodies or mark them as exceptions in `commitlint.config.cjs`; if a dependabot PR is blocked on the title/body check, re-run the workflow instead.
+Dependabot PRs are normalized automatically by the `commitlint.yml` `lint-pr-title` workflow (title de-duped, body replaced with a short summary). Do NOT hand-edit dependabot PR titles/bodies or mark them as exceptions in `commitlint.config.cjs`; if a dependabot PR is blocked on the title/body check, re-run the workflow instead. Patch/minor dependabot PRs are auto-merged (`dependabot-auto-merge.yml`, gated on `fetch-metadata`; `--auto` never bypasses branch protection) and their branches are kept up to date with base (`dependabot-branch-autoupdate.yml`, scheduled). Semver-major bumps intentionally route to human review.
 
 ### Test Commands
 


### PR DESCRIPTION
## What

Makes dependabot weekly group PRs actually merge — end-to-end — after the title/body lint fix (#564):

1. **`.github/workflows/dependabot-auto-merge.yml`** — on `pull_request` (opened/synchronize/reopened), guarded to `dependabot[bot]` only, reads `dependabot/fetch-metadata@v3` and runs `gh pr merge --auto --squash` for **patch/minor** updates. Semver-major routes to human review (2026 best-practice iron rule). `--auto` is a reservation, not a force: GitHub merges only once the required status checks pass, so branch protection stays the safety valve.
2. **`.github/workflows/dependabot-branch-autoupdate.yml`** — scheduled every 30 min; calls `gh pr update-branch` on any open dependabot PR whose `mergeStateStatus` is `BEHIND`. Without this, merging one group PR advances `main` and leaves the others stalled by "require branches up to date" (the exact "always needs latest branch" complaint).
3. **`AGENTS.md`** — policy paragraph updated to document the automerge path and the major→human rule.

## Why this is needed

`allow_auto_merge` is enabled and branch protection requires `Lint`/`Sample Run`/`Quality Gate`/`E2E` strict — but **nothing in-repo ever armed auto-merge**, and native auto-merge does not auto-rebase `BEHIND` branches. These two workflows close both gaps.

## Verification

- `yamllint` and `actionlint` pass on both new workflows.
- `github.actor == 'dependabot[bot]'` guard matches the canonical actor value (same as #564).
- Explicit `permissions:` are respected for dependabot-triggered `pull_request` runs since Oct 2021 (official changelog), so `gh pr merge --auto` can write.
- New commit message passes commitlint.

Safety: majors, conflicts (`DIRTY`), and non-dependabot PRs are untouched; `--auto` never bypasses branch protection.
