### PR TITLE
refactor(cli): drop unnecessary Sync bound on prewarm resolve closure

### DIFF
--- a/cli/src/startup.rs
+++ b/cli/src/startup.rs
@@ -59,7 +59,7 @@ pub async fn prewarm_domains<F, Fut>(
     resolve: F,
 ) -> anyhow::Result<()>
 where
-    F: Fn(String) -> Fut + Clone + Send + Sync + 'static,
+    F: Fn(String) -> Fut + Clone + Send + 'static,
     Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
 {
     // A zero limit would deadlock the spawn loop on the first acquire; treat


### PR DESCRIPTION
Relaxes the `prewarm_domains` closure bound from `Fn(...) + Clone + Send + Sync + 'static` to `Fn(...) + Clone + Send + 'static`.

`Sync` is never exercised: the closure is cloned per task and moved into each `JoinSet` task by value, so no code shares `F` by reference across threads. Dropping it accepts valid `Send`-but-not-`Sync` closures. No behavior change; `cargo test` 140 pass, clippy `-D warnings` clean.