### PR TITLE
chore(release): v0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## [Unreleased]
+## [0.3.10] - 2026-08-11
 
 ### Added
 
+- **CLI**: close out cache pre-warming — offline integration tests, `[routing.prewarm]` config block, documentation (#570)
+- **CI**: nightly integration test for JS-heavy LLM-ready markdown (#571)
 - **Cascade**: FetchTier enum and stealth escalation layer for provider tier mapping (#509, #488)
 - **Resolver**: ReadonlyResolverProtocol for typed provider callables (#508)
 - **Resolver**: visual_clip provider wired into URL resolution cascade
@@ -18,6 +20,8 @@
 
 ### Changed
 
+- **CLI**: refactor dead-code removal, split utils into package, expand config output (#575)
+- **CLI**: drop unnecessary Sync bound on prewarm resolve closure (#573)
 - **Resolver**: align synthesis logic with 2026 LLM-ready standards (#511)
 - **CLI**: optimize semantic cache metrics and redundancy pruning
 - **CLI**: optimize deterministic merge reducing line allocations

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "do-wdr"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 rust-version = "1.85"
 description = "Web Documentation Resolver CLI"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser, Debug)]
 #[command(name = "do-wdr")]
 #[command(about = "Web Documentation Resolver - Resolve URLs and queries into documentation", long_about = None)]
-#[command(version = "0.3.9")]
+#[command(version = "0.3.10")]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "do-web-doc-resolver"
-version = "0.3.9"
+version = "0.3.10"
 description = "Resolve queries or URLs into compact, LLM-ready markdown using a low-cost cascade"
 readme = "README.md"
 license = {text = "MIT"}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "do-web-doc-resolver-ui",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Release v0.3.10

Bumps all version files (pyproject.toml, Cargo.toml, package.json, cli.rs) to 0.3.10 and stamps the CHANGELOG.

CI/CD release workflow triggered by tag `v0.3.10`.